### PR TITLE
feat: support smart search plugin and expand base YAML capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,16 @@ obsidian-mcp-optimike --port 27123
 - `search <requête>`
 - `smart-search <requête>`
 - `run-template <template> --vars '{"nom":"Bob"}'`
-- `create-base --name Tasks --filter 'tag=task' --columns '["file.name","note.status"]'`
+- `create-base --file Tasks.base --filters '["tag=task"]' --order '["note.status"]'`
 - `create-canvas --name Graph --nodes '[{"type":"file","file":"A.md"},{"type":"file","file":"B.md"}]'`
 
 ## Configuration
-- **Clé API REST Obsidian** : exporter la variable `OBSIDIAN_API_TOKEN` issue du plugin Local REST API.
+ - **Clé API REST Obsidian** : exporter la variable `OBSIDIAN_API_KEY` issue du plugin Local REST API.
 - **Chemin du vault** : détecté automatiquement, peut être surchargé via les paramètres du serveur.
+- **SMART_SEARCH_MODE** : `auto` (défaut), `plugin` ou `local` pour forcer la stratégie de recherche sémantique.
+- L'outil `create-base` produit un YAML minimal centré sur `views:` et peut définir `properties` (objets de configuration comme `displayName`) et `formulas`.
+  Pour les détails complets de la syntaxe Bases, voir la documentation officielle :
+  [views](https://help.obsidian.md/bases/views), [functions](https://help.obsidian.md/bases/functions), [syntax](https://help.obsidian.md/bases/syntax).
 
 ## Sécurité & Confidentialité
 Toutes les opérations se font en local. Aucune donnée n'est envoyée vers l'extérieur. La clé API n'est jamais journalisée.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -104,6 +104,9 @@ const EnvSchema = z.object({
     .int()
     .positive()
     .default(30000),
+  SMART_SEARCH_MODE: z
+    .enum(["auto", "plugin", "local"])
+    .default("auto"),
 });
 
 const parsedEnv = EnvSchema.safeParse(process.env);
@@ -214,6 +217,7 @@ export const config = {
   obsidianCacheRefreshIntervalMin: env.OBSIDIAN_CACHE_REFRESH_INTERVAL_MIN,
   obsidianEnableCache: env.OBSIDIAN_ENABLE_CACHE,
   obsidianApiSearchTimeoutMs: env.OBSIDIAN_API_SEARCH_TIMEOUT_MS,
+  smartSearchMode: env.SMART_SEARCH_MODE,
 };
 
 /**

--- a/src/services/obsidianRestAPI/methods/searchMethods.ts
+++ b/src/services/obsidianRestAPI/methods/searchMethods.ts
@@ -9,6 +9,8 @@ import {
   SimpleSearchResult,
   ComplexSearchResult,
   RequestFunction,
+  SmartSearchArgs,
+  SmartSearchResponse,
 } from "../types.js";
 
 /**
@@ -61,5 +63,28 @@ export async function searchComplex(
     },
     context,
     "searchComplex",
+  );
+}
+
+/**
+ * Performs a semantic smart search via the Smart Connections plugin.
+ * @param _request - Internal request function from the service instance.
+ * @param args - Search arguments.
+ * @param context - Request context.
+ * @returns Results from the smart search endpoint.
+ */
+export async function searchSmart(
+  _request: RequestFunction,
+  args: SmartSearchArgs,
+  context: RequestContext,
+): Promise<SmartSearchResponse> {
+  return _request<SmartSearchResponse>(
+    {
+      method: "POST",
+      url: "/search/smart/",
+      data: args,
+    },
+    context,
+    "searchSmart",
   );
 }

--- a/src/services/obsidianRestAPI/service.ts
+++ b/src/services/obsidianRestAPI/service.ts
@@ -31,6 +31,8 @@ import {
   PatchOptions,
   Period,
   SimpleSearchResult,
+  SmartSearchArgs,
+  SmartSearchResponse,
 } from "./types.js"; // Import types from the new file
 
 export class ObsidianRestApiService {
@@ -351,6 +353,29 @@ export class ObsidianRestApiService {
       this._request.bind(this),
       query,
       contentType,
+      context,
+    );
+  }
+
+  /**
+   * Performs a semantic smart search using the Smart Connections plugin.
+   * @param query - Search query string.
+   * @param limit - Maximum number of results to return.
+   * @param context - Request context.
+   * @returns Smart search results.
+   */
+  async smartSearch(
+    query: string,
+    limit: number | undefined,
+    context: RequestContext,
+  ): Promise<SmartSearchResponse> {
+    const args: SmartSearchArgs = { query };
+    if (typeof limit === "number") {
+      args.limit = limit;
+    }
+    return searchMethods.searchSmart(
+      this._request.bind(this),
+      args,
       context,
     );
   }

--- a/src/services/obsidianRestAPI/types.ts
+++ b/src/services/obsidianRestAPI/types.ts
@@ -87,6 +87,31 @@ export interface ComplexSearchResult {
 }
 
 /**
+ * Arguments for semantic smart search.
+ */
+export interface SmartSearchArgs {
+  query: string;
+  limit?: number;
+}
+
+/**
+ * A single result from semantic smart search.
+ */
+export interface SmartSearchHit {
+  filePath: string;
+  score: number;
+  snippet?: string;
+  title?: string;
+}
+
+/**
+ * Response payload returned by the smart search endpoint.
+ */
+export interface SmartSearchResponse {
+  results: SmartSearchHit[];
+}
+
+/**
  * Structure for an available Obsidian command.
  */
 export interface ObsidianCommand {

--- a/tests/tools/createBaseTool.test.js
+++ b/tests/tools/createBaseTool.test.js
@@ -15,10 +15,24 @@ describe('createBaseTool', () => {
     const server = new MockServer();
     const { registerCreateBaseTool } = await import('../../dist/tools/createBaseTool.js');
     await registerCreateBaseTool(server, obsidian);
-    await server.handler({ name: 'Tasks', filters: { tag: 'task' }, columns: ['file.name', 'note.status'], sort: 'note.status' }, {});
+    await server.handler(
+      {
+        filePath: 'Tasks.base',
+        name: 'Tasks',
+        filters: ['tag=task'],
+        order: ['note.status'],
+        viewType: 'table',
+        properties: { status: { displayName: 'Status', default: 'todo' } },
+        formulas: { isDone: 'status = "done"' },
+      },
+      {},
+    );
     const content = await fs.readFile(path.join(dir, 'Tasks.base'), 'utf8');
     const parsed = yaml.load(content);
-    expect(parsed.filters.tag).toBe('task');
-    expect(parsed.columns).toContain('note.status');
+    expect(parsed.views[0].filters).toBe('tag=task');
+    expect(parsed.views[0].order[0]).toBe('note.status');
+    expect(parsed.properties.status.displayName).toBe('Status');
+    expect(parsed.properties.status.default).toBe('todo');
+    expect(parsed.formulas.isDone).toBe('status = "done"');
   });
 });

--- a/tests/tools/semanticSearchTool.test.js
+++ b/tests/tools/semanticSearchTool.test.js
@@ -1,0 +1,47 @@
+process.env.OBSIDIAN_API_KEY = 'test';
+import { jest } from '@jest/globals';
+
+class MockServer { tool(_n,_d,_s,h){ this.handler = h; } }
+
+describe('semanticSearchTool', () => {
+  test('uses plugin when available', async () => {
+    process.env.SMART_SEARCH_MODE = 'plugin';
+    jest.resetModules();
+    const obsidian = {
+      smartSearch: async () => ({ results: [{ filePath: 'A.md', score: 0.9 }] })
+    };
+    const vault = { getCache: () => new Map() };
+    const server = new MockServer();
+    const { registerSemanticSearchTool } = await import('../../dist/tools/semanticSearchTool.js');
+    await registerSemanticSearchTool(server, obsidian, vault);
+    const res = await server.handler({ query: 'hello', limit: 5 }, {});
+    expect(res.content[0].json.method).toBe('semantic');
+    expect(res.content[0].json.results[0].path).toBe('A.md');
+  });
+
+  test('falls back to tfidf when plugin fails', async () => {
+    process.env.SMART_SEARCH_MODE = 'auto';
+    jest.resetModules();
+    let called = 0;
+    const obsidian = {
+      smartSearch: async () => {
+        called++;
+        throw new Error('no plugin');
+      },
+    };
+    const vault = {
+      getCache: () =>
+        new Map([
+          ['A.md', { content: 'hello world' }],
+          ['B.md', { content: 'another note' }],
+        ]),
+    };
+    const server = new MockServer();
+    const { registerSemanticSearchTool } = await import('../../dist/tools/semanticSearchTool.js');
+    await registerSemanticSearchTool(server, obsidian, vault);
+    const res = await server.handler({ query: 'hello', limit: 1 }, {});
+    expect(called).toBe(1);
+    expect(res.content[0].json.method).toBe('lexical');
+    expect(res.content[0].json.results[0].path).toBe('A.md');
+  });
+});


### PR DESCRIPTION
## Summary
- add semantic smart search with plugin endpoint and TF-IDF fallback
- extend `create-base` tool to emit `properties` and `formulas` alongside `views`
- document SMART_SEARCH_MODE variable and link to Bases YAML syntax
- relax `create-base` property schema to accept generic config objects like `displayName`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be65197428832aa5e5aa3b683823ec