### PR TITLE
fix: return empty smart-search results and format code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2025-09-08
 
 ### Ajouté
+
 - Serveur MCP unifié combinant les outils principaux dans un seul paquet.
 - Recherche sémantique `/search/smart` avec intégration des embeddings locaux et fallback TF‑IDF.
 - Outil d’exécution de templates avec substitutions `{{variable}}` et gestion d’erreurs.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Serveur MCP unifié pour Obsidian permettant aux agents IA d'interagir avec votre coffre local. Il expose des outils via le protocole MCP et peut fonctionner en mode STDIO (par défaut, idéal pour Codex ou Claude CLI) ou via HTTP + SSE.
 
 ## Fonctionnalités
+
 - Lecture et écriture de notes du vault via l'API REST locale ou en accès direct au fichier.
 - Recherche texte classique et **recherche sémantique** avec fallback TF‑IDF lorsque les embeddings ne sont pas disponibles.
 - Exécution de templates Obsidian avec substitution de variables `{{...}}`.
@@ -10,26 +11,35 @@ Serveur MCP unifié pour Obsidian permettant aux agents IA d'interagir avec votr
 - Autres utilitaires: vérification de santé, liste des modèles, etc.
 
 ## Installation
+
 ```bash
 npm install -g obsidian-mcp-optimike
 ```
+
 ou exécution directe sans installation:
+
 ```bash
 npx -y obsidian-mcp-optimike --stdio
 ```
+
 Binaire disponible pour Windows, macOS et Linux.
 
 ## Usage
+
 ### Mode STDIO
+
 ```bash
 obsidian-mcp-optimike --stdio
 ```
+
 ### Mode HTTP
+
 ```bash
 obsidian-mcp-optimike --port 27123
 ```
 
 ### Outils CLI principaux
+
 - `read-file <chemin>`
 - `write-file <chemin> --content "..."`
 - `search <requête>`
@@ -39,7 +49,8 @@ obsidian-mcp-optimike --port 27123
 - `create-canvas --name Graph --nodes '[{"type":"file","file":"A.md"},{"type":"file","file":"B.md"}]'`
 
 ## Configuration
- - **Clé API REST Obsidian** : exporter la variable `OBSIDIAN_API_KEY` issue du plugin Local REST API.
+
+- **Clé API REST Obsidian** : exporter la variable `OBSIDIAN_API_KEY` issue du plugin Local REST API.
 - **Chemin du vault** : détecté automatiquement, peut être surchargé via les paramètres du serveur.
 - **SMART_SEARCH_MODE** : `auto` (défaut), `plugin` ou `local` pour forcer la stratégie de recherche sémantique.
 - L'outil `create-base` produit un YAML minimal centré sur `views:` et peut définir `properties` (objets de configuration comme `displayName`) et `formulas`.
@@ -47,19 +58,24 @@ obsidian-mcp-optimike --port 27123
   [views](https://help.obsidian.md/bases/views), [functions](https://help.obsidian.md/bases/functions), [syntax](https://help.obsidian.md/bases/syntax).
 
 ## Sécurité & Confidentialité
+
 Toutes les opérations se font en local. Aucune donnée n'est envoyée vers l'extérieur. La clé API n'est jamais journalisée.
 
 ## Développement
+
 ```bash
 npm test
 npm run build
 ```
+
 Les contributions sont les bienvenues (licence MIT).
 
 ## Feuille de route
+
 - Support amélioré des embeddings locaux
 - Transport WebSocket
 - Indexation incrémentale pour de grands vaults
 
 ## Remerciements
+
 Basé sur les plugins communautaires Obsidian (Local REST API, Smart Connections) et des travaux open source associés.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -104,9 +104,7 @@ const EnvSchema = z.object({
     .int()
     .positive()
     .default(30000),
-  SMART_SEARCH_MODE: z
-    .enum(["auto", "plugin", "local"])
-    .default("auto"),
+  SMART_SEARCH_MODE: z.enum(["auto", "plugin", "local"]).default("auto"),
 });
 
 const parsedEnv = EnvSchema.safeParse(process.env);

--- a/src/semantic/embeddingSearch.ts
+++ b/src/semantic/embeddingSearch.ts
@@ -16,7 +16,10 @@ export function embeddingSearch(
   topK = 5,
 ): ScoredEmbedding[] {
   return docs
-    .map((d) => ({ ...d, score: cosineSimilarity(queryEmbedding, d.embedding) }))
+    .map((d) => ({
+      ...d,
+      score: cosineSimilarity(queryEmbedding, d.embedding),
+    }))
     .sort((a, b) => b.score - a.score)
     .slice(0, topK);
 }

--- a/src/semantic/service.ts
+++ b/src/semantic/service.ts
@@ -1,5 +1,9 @@
 import OpenAI from "openai";
-import { embeddingSearch, EmbeddedDocument, ScoredEmbedding } from "./embeddingSearch.js";
+import {
+  embeddingSearch,
+  EmbeddedDocument,
+  ScoredEmbedding,
+} from "./embeddingSearch.js";
 
 export interface Result {
   id: string;
@@ -13,7 +17,10 @@ export class SemanticService {
   private documents: EmbeddedDocument[] = [];
   constructor(private embedder: Embedder) {}
 
-  static withOpenAI(apiKey: string, model = "text-embedding-3-small"): SemanticService {
+  static withOpenAI(
+    apiKey: string,
+    model = "text-embedding-3-small",
+  ): SemanticService {
     const client = new OpenAI({ apiKey });
     const embedder: Embedder = async (input: string) => {
       const res = await client.embeddings.create({ model, input });
@@ -37,6 +44,10 @@ export class SemanticService {
       this.documents,
       topK,
     );
-    return scored.map((d) => ({ id: d.id, text: d.text ?? "", score: d.score }));
+    return scored.map((d) => ({
+      id: d.id,
+      text: d.text ?? "",
+      score: d.score,
+    }));
   }
 }

--- a/src/semantic/tfidf.ts
+++ b/src/semantic/tfidf.ts
@@ -40,9 +40,7 @@ export class TfIdf {
     for (const t of tokens) {
       tf.set(t, (tf.get(t) ?? 0) + 1);
     }
-    return terms.map(
-      (term) => (tf.get(term) ?? 0) * (this.idf.get(term) ?? 0),
-    );
+    return terms.map((term) => (tf.get(term) ?? 0) * (this.idf.get(term) ?? 0));
   }
 
   public search(query: string): ScoredDoc[] {

--- a/src/services/obsidianRestAPI/service.ts
+++ b/src/services/obsidianRestAPI/service.ts
@@ -373,11 +373,7 @@ export class ObsidianRestApiService {
     if (typeof limit === "number") {
       args.limit = limit;
     }
-    return searchMethods.searchSmart(
-      this._request.bind(this),
-      args,
-      context,
-    );
+    return searchMethods.searchSmart(this._request.bind(this), args, context);
   }
 
   // --- Command Methods ---

--- a/src/services/search/tfidfFallback.ts
+++ b/src/services/search/tfidfFallback.ts
@@ -42,7 +42,8 @@ export function rankDocumentsTFIDF(
   for (const doc of docsTokens) {
     let score = 0;
     for (const term of queryTerms) {
-      const termFreq = doc.tokens.filter((t) => t === term).length / doc.tokens.length;
+      const termFreq =
+        doc.tokens.filter((t) => t === term).length / doc.tokens.length;
       score += termFreq * idf[term];
     }
     scores.push({ path: doc.path, score });

--- a/src/tools/createBaseTool.ts
+++ b/src/tools/createBaseTool.ts
@@ -12,22 +12,10 @@ import { BaseErrorCode } from "../types-global/errors.js";
 
 const CreateBaseInputSchema = z
   .object({
-    filePath: z
-      .string()
-      .min(1)
-      .describe("Path of the .base file to create."),
-    name: z
-      .string()
-      .default("View")
-      .describe("Name of the view."),
-    filters: z
-      .array(z.string())
-      .default([])
-      .describe("Filter expressions."),
-    order: z
-      .array(z.string())
-      .default([])
-      .describe("Order directives."),
+    filePath: z.string().min(1).describe("Path of the .base file to create."),
+    name: z.string().default("View").describe("Name of the view."),
+    filters: z.array(z.string()).default([]).describe("Filter expressions."),
+    order: z.array(z.string()).default([]).describe("Order directives."),
     viewType: z
       .enum(["table", "cards"])
       .default("table")
@@ -42,12 +30,11 @@ const CreateBaseInputSchema = z
       .record(z.record(z.any()))
       .optional()
       .describe("Configuration des propriétés de la base (ex. displayName)."),
-    formulas: z
-      .record(z.string())
-      .optional()
-      .describe("Formules calculées."),
+    formulas: z.record(z.string()).optional().describe("Formules calculées."),
   })
-  .describe("Creates an Obsidian Base (.base) file with a minimal YAML structure.");
+  .describe(
+    "Creates an Obsidian Base (.base) file with a minimal YAML structure.",
+  );
 
 export const CreateBaseInputSchemaShape = CreateBaseInputSchema.shape;
 export type CreateBaseInput = z.infer<typeof CreateBaseInputSchema>;
@@ -151,4 +138,3 @@ export async function registerCreateBaseTool(
     },
   );
 }
-

--- a/src/tools/createCanvasTool.ts
+++ b/src/tools/createCanvasTool.ts
@@ -82,9 +82,7 @@ export async function registerCreateCanvasTool(
                 ...(node.type === "file" && node.file
                   ? { file: node.file }
                   : {}),
-                ...(node.type === "text"
-                  ? { text: node.text ?? "" }
-                  : {}),
+                ...(node.type === "text" ? { text: node.text ?? "" } : {}),
               }));
 
               const edges = (params.edges ?? []).map((edge) => ({
@@ -135,4 +133,3 @@ export async function registerCreateCanvasTool(
     },
   );
 }
-

--- a/src/tools/executeTemplateTool.ts
+++ b/src/tools/executeTemplateTool.ts
@@ -11,10 +11,7 @@ import { BaseErrorCode, McpError } from "../types-global/errors.js";
 
 const ExecuteTemplateInputSchema = z
   .object({
-    template: z
-      .string()
-      .min(1)
-      .describe("Template name or path."),
+    template: z.string().min(1).describe("Template name or path."),
     variables: z
       .record(z.string())
       .optional()
@@ -107,12 +104,15 @@ export async function registerExecuteTemplateTool(
               }
 
               const vars = params.variables ?? {};
-              const filled = templateContent.replace(/\{\{(.*?)\}\}/g, (_, name) => {
-                const key = name.trim();
-                return Object.prototype.hasOwnProperty.call(vars, key)
-                  ? String(vars[key])
-                  : `{{${key}}}`;
-              });
+              const filled = templateContent.replace(
+                /\{\{(.*?)\}\}/g,
+                (_, name) => {
+                  const key = name.trim();
+                  return Object.prototype.hasOwnProperty.call(vars, key)
+                    ? String(vars[key])
+                    : `{{${key}}}`;
+                },
+              );
 
               if (params.outputPath) {
                 await obsidianService.updateFileContent(
@@ -158,4 +158,3 @@ export async function registerExecuteTemplateTool(
     },
   );
 }
-

--- a/src/tools/semanticSearchTool.ts
+++ b/src/tools/semanticSearchTool.ts
@@ -9,15 +9,12 @@ import {
   RequestContext,
   requestContextService,
 } from "../utils/index.js";
-import { BaseErrorCode, McpError } from "../types-global/errors.js";
+import { BaseErrorCode } from "../types-global/errors.js";
 import { config } from "../config/index.js";
 
 const SmartSearchInputSchema = z
   .object({
-    query: z
-      .string()
-      .min(1)
-      .describe("Search query string."),
+    query: z.string().min(1).describe("Search query string."),
     limit: z
       .number()
       .int()
@@ -111,8 +108,7 @@ export async function registerSemanticSearchTool(
                     "smart-search plugin failed, attempting fallback",
                     {
                       ...handlerContext,
-                      error:
-                        err instanceof Error ? err.message : String(err),
+                      error: err instanceof Error ? err.message : String(err),
                     },
                   );
                 }
@@ -134,9 +130,8 @@ export async function registerSemanticSearchTool(
               }
 
               if (results.length === 0) {
-                throw new McpError(
-                  BaseErrorCode.INTERNAL_ERROR,
-                  "smart-search: no results",
+                logger.debug(
+                  "smart-search returned no results",
                   handlerContext,
                 );
               }
@@ -183,4 +178,3 @@ export async function registerSemanticSearchTool(
     },
   );
 }
-

--- a/tests/mocks/obsidian-rest-mock.ts
+++ b/tests/mocks/obsidian-rest-mock.ts
@@ -1,6 +1,6 @@
-import express from 'express';
-import path from 'node:path';
-import fs from 'node:fs/promises';
+import express from "express";
+import path from "node:path";
+import fs from "node:fs/promises";
 
 export interface MockServer {
   app: express.Express;
@@ -10,45 +10,45 @@ export interface MockServer {
 
 export async function startObsidianRestMock(
   vaultDir: string,
-  options: { port?: number; token?: string } = {}
+  options: { port?: number; token?: string } = {},
 ): Promise<MockServer> {
   const port = options.port ?? 27123;
-  const token = options.token ?? process.env.OBSIDIAN_API_TOKEN ?? 'test-token';
+  const token = options.token ?? process.env.OBSIDIAN_API_TOKEN ?? "test-token";
 
   const app = express();
   app.use(express.json());
 
   // auth middleware
   app.use((req, res, next) => {
-    if (req.path === '/health') return next();
-    const auth = req.header('authorization');
+    if (req.path === "/health") return next();
+    const auth = req.header("authorization");
     if (auth !== `Bearer ${token}`) {
-      return res.status(401).json({ error: 'unauthorized' });
+      return res.status(401).json({ error: "unauthorized" });
     }
     next();
   });
 
-  app.get('/health', (_req, res) => {
+  app.get("/health", (_req, res) => {
     res.json({ authenticated: true });
   });
 
-  app.get('/vault/*', async (req, res) => {
+  app.get("/vault/*", async (req, res) => {
     const relPath = req.params[0];
     const filePath = path.join(vaultDir, relPath);
     try {
-      const data = await fs.readFile(filePath, 'utf8');
+      const data = await fs.readFile(filePath, "utf8");
       res.send(data);
     } catch {
-      res.status(404).send('Not Found');
+      res.status(404).send("Not Found");
     }
   });
 
-  app.post('/vault/*', async (req, res) => {
+  app.post("/vault/*", async (req, res) => {
     const relPath = req.params[0];
     const filePath = path.join(vaultDir, relPath);
-    const content = typeof req.body === 'string' ? req.body : req.body.content;
+    const content = typeof req.body === "string" ? req.body : req.body.content;
     await fs.mkdir(path.dirname(filePath), { recursive: true });
-    await fs.writeFile(filePath, content ?? '', 'utf8');
+    await fs.writeFile(filePath, content ?? "", "utf8");
     res.json({ success: true });
   });
 

--- a/tests/services/tfidfFallback.test.js
+++ b/tests/services/tfidfFallback.test.js
@@ -1,13 +1,13 @@
-import { rankDocumentsTFIDF } from '../../dist/services/search/tfidfFallback.js';
+import { rankDocumentsTFIDF } from "../../dist/services/search/tfidfFallback.js";
 
-describe('rankDocumentsTFIDF', () => {
-  test('returns most relevant doc', () => {
+describe("rankDocumentsTFIDF", () => {
+  test("returns most relevant doc", () => {
     const docs = [
-      { path: 'a.md', text: 'hello world' },
-      { path: 'b.md', text: 'another file' },
-      { path: 'c.md', text: 'world of code' }
+      { path: "a.md", text: "hello world" },
+      { path: "b.md", text: "another file" },
+      { path: "c.md", text: "world of code" },
     ];
-    const results = rankDocumentsTFIDF('hello', docs);
-    expect(results[0].path).toBe('a.md');
+    const results = rankDocumentsTFIDF("hello", docs);
+    expect(results[0].path).toBe("a.md");
   });
 });

--- a/tests/tools/createBaseTool.test.js
+++ b/tests/tools/createBaseTool.test.js
@@ -1,54 +1,62 @@
-process.env.OBSIDIAN_API_KEY = 'test';
-import fs from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
-import yaml from 'js-yaml';
+process.env.OBSIDIAN_API_KEY = "test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import yaml from "js-yaml";
 
-class MockServer { tool(_n,_d,_s,h){ this.handler = h; } }
+class MockServer {
+  tool(_n, _d, _s, h) {
+    this.handler = h;
+  }
+}
 
-describe('createBaseTool', () => {
-  test('writes base file', async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'vault-'));
+describe("createBaseTool", () => {
+  test("writes base file", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vault-"));
     const obsidian = {
-      updateFileContent: (p, c) => fs.writeFile(path.join(dir, p), c, 'utf8')
+      updateFileContent: (p, c) => fs.writeFile(path.join(dir, p), c, "utf8"),
     };
     const server = new MockServer();
-    const { registerCreateBaseTool } = await import('../../dist/tools/createBaseTool.js');
+    const { registerCreateBaseTool } = await import(
+      "../../dist/tools/createBaseTool.js"
+    );
     await registerCreateBaseTool(server, obsidian);
     await server.handler(
       {
-        filePath: 'Tasks.base',
-        name: 'Tasks',
-        filters: ['tag=task'],
-        order: ['note.status'],
-        viewType: 'table',
-        properties: { status: { displayName: 'Status', default: 'todo' } },
+        filePath: "Tasks.base",
+        name: "Tasks",
+        filters: ["tag=task"],
+        order: ["note.status"],
+        viewType: "table",
+        properties: { status: { displayName: "Status", default: "todo" } },
         formulas: { isDone: 'status = "done"' },
       },
       {},
     );
-    const content = await fs.readFile(path.join(dir, 'Tasks.base'), 'utf8');
+    const content = await fs.readFile(path.join(dir, "Tasks.base"), "utf8");
     const parsed = yaml.load(content);
-    expect(parsed.views[0].filters).toBe('tag=task');
-    expect(parsed.views[0].order[0]).toBe('note.status');
-    expect(parsed.properties.status.displayName).toBe('Status');
-    expect(parsed.properties.status.default).toBe('todo');
+    expect(parsed.views[0].filters).toBe("tag=task");
+    expect(parsed.views[0].order[0]).toBe("note.status");
+    expect(parsed.properties.status.displayName).toBe("Status");
+    expect(parsed.properties.status.default).toBe("todo");
     expect(parsed.formulas.isDone).toBe('status = "done"');
   });
 
-  test('applies defaults when optional fields omitted', async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'vault-'));
+  test("applies defaults when optional fields omitted", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vault-"));
     const obsidian = {
-      updateFileContent: (p, c) => fs.writeFile(path.join(dir, p), c, 'utf8')
+      updateFileContent: (p, c) => fs.writeFile(path.join(dir, p), c, "utf8"),
     };
     const server = new MockServer();
-    const { registerCreateBaseTool } = await import('../../dist/tools/createBaseTool.js');
+    const { registerCreateBaseTool } = await import(
+      "../../dist/tools/createBaseTool.js"
+    );
     await registerCreateBaseTool(server, obsidian);
-    await server.handler({ filePath: 'Default.base' }, {});
-    const content = await fs.readFile(path.join(dir, 'Default.base'), 'utf8');
+    await server.handler({ filePath: "Default.base" }, {});
+    const content = await fs.readFile(path.join(dir, "Default.base"), "utf8");
     const parsed = yaml.load(content);
-    expect(parsed.views[0].name).toBe('View');
-    expect(parsed.views[0].type).toBe('table');
+    expect(parsed.views[0].name).toBe("View");
+    expect(parsed.views[0].type).toBe("table");
     expect(parsed.views[0].filters).toBeUndefined();
   });
 });

--- a/tests/tools/createCanvasTool.test.js
+++ b/tests/tools/createCanvasTool.test.js
@@ -1,28 +1,40 @@
-process.env.OBSIDIAN_API_KEY = 'test';
-import fs from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
+process.env.OBSIDIAN_API_KEY = "test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
-class MockServer { tool(_n,_d,_s,h){ this.handler = h; } }
+class MockServer {
+  tool(_n, _d, _s, h) {
+    this.handler = h;
+  }
+}
 
-describe('createCanvasTool', () => {
-  test('writes canvas file', async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'vault-'));
+describe("createCanvasTool", () => {
+  test("writes canvas file", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vault-"));
     const obsidian = {
-      updateFileContent: (p, c) => fs.writeFile(path.join(dir, p), c, 'utf8')
+      updateFileContent: (p, c) => fs.writeFile(path.join(dir, p), c, "utf8"),
     };
     const server = new MockServer();
-    const { registerCreateCanvasTool } = await import('../../dist/tools/createCanvasTool.js');
+    const { registerCreateCanvasTool } = await import(
+      "../../dist/tools/createCanvasTool.js"
+    );
     await registerCreateCanvasTool(server, obsidian);
-    await server.handler({
-      name: 'Graph',
-      nodes: [{ id: 'A', type: 'file', file: 'A.md' }, { id: 'B', type: 'file', file: 'B.md' }],
-      edges: [{ from: 'A', to: 'B', label: 'relates' }]
-    }, {});
-    const content = await fs.readFile(path.join(dir, 'Graph.canvas'), 'utf8');
+    await server.handler(
+      {
+        name: "Graph",
+        nodes: [
+          { id: "A", type: "file", file: "A.md" },
+          { id: "B", type: "file", file: "B.md" },
+        ],
+        edges: [{ from: "A", to: "B", label: "relates" }],
+      },
+      {},
+    );
+    const content = await fs.readFile(path.join(dir, "Graph.canvas"), "utf8");
     const parsed = JSON.parse(content);
     expect(parsed.nodes).toHaveLength(2);
-    expect(parsed.edges[0].from).toBe('A');
-    expect(parsed.edges[0].to).toBe('B');
+    expect(parsed.edges[0].from).toBe("A");
+    expect(parsed.edges[0].to).toBe("B");
   });
 });

--- a/tests/tools/executeTemplateTool.test.js
+++ b/tests/tools/executeTemplateTool.test.js
@@ -1,36 +1,52 @@
-process.env.OBSIDIAN_API_KEY = 'test';
-import fs from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
+process.env.OBSIDIAN_API_KEY = "test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 class MockServer {
-  tool(_n,_d,_s,h){ this.handler = h; }
+  tool(_n, _d, _s, h) {
+    this.handler = h;
+  }
 }
 
-describe('executeTemplateTool', () => {
-  test('fills placeholders', async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'vault-'));
-    await fs.mkdir(path.join(dir, 'Templates'), { recursive: true });
-    await fs.writeFile(path.join(dir, 'Templates', 'greet.md'), 'Hello {{name}}');
+describe("executeTemplateTool", () => {
+  test("fills placeholders", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vault-"));
+    await fs.mkdir(path.join(dir, "Templates"), { recursive: true });
+    await fs.writeFile(
+      path.join(dir, "Templates", "greet.md"),
+      "Hello {{name}}",
+    );
     const obsidian = {
-      getFileContent: (p) => fs.readFile(path.join(dir, p), 'utf8'),
-      updateFileContent: (p, c) => fs.writeFile(path.join(dir, p), c, 'utf8')
+      getFileContent: (p) => fs.readFile(path.join(dir, p), "utf8"),
+      updateFileContent: (p, c) => fs.writeFile(path.join(dir, p), c, "utf8"),
     };
     const server = new MockServer();
-    const { registerExecuteTemplateTool } = await import('../../dist/tools/executeTemplateTool.js');
+    const { registerExecuteTemplateTool } = await import(
+      "../../dist/tools/executeTemplateTool.js"
+    );
     await registerExecuteTemplateTool(server, obsidian);
-    const res = await server.handler({ template: 'greet.md', variables: { name: 'World' } }, {});
-    expect(res.content[0].json.content).toBe('Hello World');
+    const res = await server.handler(
+      { template: "greet.md", variables: { name: "World" } },
+      {},
+    );
+    expect(res.content[0].json.content).toBe("Hello World");
   });
 
-  test('throws when template missing', async () => {
+  test("throws when template missing", async () => {
     const obsidian = {
-      getFileContent: () => { throw new Error('not found'); },
-      updateFileContent: () => {}
+      getFileContent: () => {
+        throw new Error("not found");
+      },
+      updateFileContent: () => {},
     };
     const server = new MockServer();
-    const { registerExecuteTemplateTool } = await import('../../dist/tools/executeTemplateTool.js');
+    const { registerExecuteTemplateTool } = await import(
+      "../../dist/tools/executeTemplateTool.js"
+    );
     await registerExecuteTemplateTool(server, obsidian);
-    await expect(server.handler({ template: 'missing' }, {})).rejects.toThrow('Template not found');
+    await expect(server.handler({ template: "missing" }, {})).rejects.toThrow(
+      "Template not found",
+    );
   });
 });

--- a/tests/tools/semanticSearchTool.test.js
+++ b/tests/tools/semanticSearchTool.test.js
@@ -1,47 +1,57 @@
-process.env.OBSIDIAN_API_KEY = 'test';
-import { jest } from '@jest/globals';
+process.env.OBSIDIAN_API_KEY = "test";
+import { jest } from "@jest/globals";
 
-class MockServer { tool(_n,_d,_s,h){ this.handler = h; } }
+class MockServer {
+  tool(_n, _d, _s, h) {
+    this.handler = h;
+  }
+}
 
-describe('semanticSearchTool', () => {
-  test('uses plugin when available', async () => {
-    process.env.SMART_SEARCH_MODE = 'plugin';
+describe("semanticSearchTool", () => {
+  test("uses plugin when available", async () => {
+    process.env.SMART_SEARCH_MODE = "plugin";
     jest.resetModules();
     const obsidian = {
-      smartSearch: async () => ({ results: [{ filePath: 'A.md', score: 0.9 }] })
+      smartSearch: async () => ({
+        results: [{ filePath: "A.md", score: 0.9 }],
+      }),
     };
     const vault = { getCache: () => new Map() };
     const server = new MockServer();
-    const { registerSemanticSearchTool } = await import('../../dist/tools/semanticSearchTool.js');
+    const { registerSemanticSearchTool } = await import(
+      "../../dist/tools/semanticSearchTool.js"
+    );
     await registerSemanticSearchTool(server, obsidian, vault);
-    const res = await server.handler({ query: 'hello', limit: 5 }, {});
-    expect(res.content[0].json.method).toBe('semantic');
-    expect(res.content[0].json.results[0].path).toBe('A.md');
+    const res = await server.handler({ query: "hello", limit: 5 }, {});
+    expect(res.content[0].json.method).toBe("semantic");
+    expect(res.content[0].json.results[0].path).toBe("A.md");
   });
 
-  test('falls back to tfidf when plugin fails', async () => {
-    process.env.SMART_SEARCH_MODE = 'auto';
+  test("falls back to tfidf when plugin fails", async () => {
+    process.env.SMART_SEARCH_MODE = "auto";
     jest.resetModules();
     let called = 0;
     const obsidian = {
       smartSearch: async () => {
         called++;
-        throw new Error('no plugin');
+        throw new Error("no plugin");
       },
     };
     const vault = {
       getCache: () =>
         new Map([
-          ['A.md', { content: 'hello world' }],
-          ['B.md', { content: 'another note' }],
+          ["A.md", { content: "hello world" }],
+          ["B.md", { content: "another note" }],
         ]),
     };
     const server = new MockServer();
-    const { registerSemanticSearchTool } = await import('../../dist/tools/semanticSearchTool.js');
+    const { registerSemanticSearchTool } = await import(
+      "../../dist/tools/semanticSearchTool.js"
+    );
     await registerSemanticSearchTool(server, obsidian, vault);
-    const res = await server.handler({ query: 'hello', limit: 1 }, {});
+    const res = await server.handler({ query: "hello", limit: 1 }, {});
     expect(called).toBe(1);
-    expect(res.content[0].json.method).toBe('lexical');
-    expect(res.content[0].json.results[0].path).toBe('A.md');
+    expect(res.content[0].json.method).toBe("lexical");
+    expect(res.content[0].json.results[0].path).toBe("A.md");
   });
 });


### PR DESCRIPTION
## Summary
- return an empty list when semantic search finds no matches instead of throwing an internal error
- format codebase with Prettier to resolve lint warnings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be7368435c832a92869f4edecd0a55