### PR TITLE
fix: make test script cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/cyanheads/obsidian-mcp-server#readme",
   "scripts": {
     "build": "tsc && node --loader ts-node/esm scripts/make-executable.ts dist/index.js",
-    "test": "npm run build && NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "npm run build && node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
     "lint": "prettier --check \"**/*.{ts,js,json,md,html,css}\"",
     "start": "node dist/index.js",
     "start:stdio": "MCP_LOG_LEVEL=debug MCP_TRANSPORT_TYPE=stdio node dist/index.js",


### PR DESCRIPTION
## Summary
- run Jest via `node --experimental-vm-modules` to support Windows shells

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be73ca78e4832abacb2bb161622c42