### PR TITLE
fix(search): use vault cache for lexical fallback

### DIFF
--- a/src/search/smartSearch.ts
+++ b/src/search/smartSearch.ts
@@ -9,6 +9,7 @@ import {
   samePathEnd,
 } from "../utils/resolveSmartEnvDir.js";
 import { fetch as undiciFetch } from "undici";
+import type { VaultCacheService } from "../services/obsidianRestAPI/vaultCache/index.js";
 
 export type SmartSearchInput = {
   query?: string;
@@ -61,6 +62,23 @@ async function encodeQuery384(q: string): Promise<number[]> {
 
 // ---- Lexical fallback (TF-IDF) ----
 type Doc = { path: string; text: string };
+
+function docsFromCache(vcs?: VaultCacheService): Doc[] {
+  try {
+    if (!vcs) return [];
+    const cache = vcs.getCache?.();
+    if (!cache) return [];
+    const docs: Doc[] = [];
+    for (const [p, entry] of cache.entries()) {
+      if (/\.md$/i.test(p)) {
+        docs.push({ path: toPosix(p), text: entry.content });
+      }
+    }
+    return docs;
+  } catch {
+    return [];
+  }
+}
 
 function tokenize(s: string): string[] {
   return (s || "")
@@ -151,6 +169,7 @@ function findAnchor(pool: NoteVecN[], fromPath: string): NoteVecN | null {
 
 export async function smartSearch(
   input: SmartSearchInput,
+  vaultCacheService?: VaultCacheService,
 ): Promise<SmartSearchOutput> {
   const query = (input.query ?? "").trim();
   const fromPath = input.fromPath?.trim();
@@ -209,7 +228,10 @@ export async function smartSearch(
 
   // 3) Lexical TF-IDF
   if (wantQuery || wantNeighbors) {
-    const docs = await fetchVaultDocs();
+    let docs = docsFromCache(vaultCacheService);
+    if (!docs.length) {
+      docs = await fetchVaultDocs();
+    }
     let lexicalQuery = query;
     if (!lexicalQuery && wantNeighbors) {
       lexicalQuery =

--- a/src/tools/semanticSearchTool.ts
+++ b/src/tools/semanticSearchTool.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { smartSearch } from "../search/smartSearch.js";
+import type { VaultCacheService } from "../services/obsidianRestAPI/vaultCache/index.js";
 
 export type Input = { query?: string; fromPath?: string; limit?: number };
 export type Output = {
@@ -19,9 +20,9 @@ const tool = {
       limit: { type: "number" },
     },
   },
-  async execute(input: Input): Promise<Output> {
+  async execute(input: Input, vcs?: VaultCacheService): Promise<Output> {
     try {
-      return await smartSearch(input);
+      return await smartSearch(input, vcs);
     } catch {
       return { method: "lexical", results: [] };
     }
@@ -33,14 +34,14 @@ export default tool;
 export async function registerSemanticSearchTool(
   server: McpServer,
   _obsidian: any,
-  _vault?: any,
+  vaultCacheService?: VaultCacheService,
 ): Promise<void> {
   server.tool(
     tool.name,
     tool.description,
     tool.inputSchema as any,
     async (args: any) => {
-      const result = await tool.execute(args as Input);
+      const result = await tool.execute(args as Input, vaultCacheService);
       return {
         content: [{ type: "application/json", json: result } as any],
         isError: false,

--- a/tests/tools/semanticSearchTool.test.js
+++ b/tests/tools/semanticSearchTool.test.js
@@ -22,6 +22,25 @@ describe("semanticSearchTool", () => {
     }
   });
 
+  test("uses vault cache when API config missing", async () => {
+    process.env.SMART_SEARCH_MODE = "lexical";
+    const cache = new Map([
+      ["A.md", { content: "hello world", mtime: 0 }],
+      ["B.md", { content: "another note", mtime: 0 }],
+    ]);
+    const server = new MockServer();
+    const { registerSemanticSearchTool } = await import(
+      "../../dist/tools/semanticSearchTool.js"
+    );
+    await registerSemanticSearchTool(server, {}, { getCache: () => cache });
+    const res = await server.handler({ query: "hello", limit: 1 }, {});
+    expect(res.method || res.content?.[0]?.json?.method).toBe("lexical");
+    const result = res.results
+      ? res.results[0]
+      : res.content[0].json.results[0];
+    expect(result.path).toBe("A.md");
+  });
+
   test("falls back to tfidf when only query is provided", async () => {
     process.env.SMART_SEARCH_MODE = "lexical";
     process.env.OBSIDIAN_BASE_URL = "http://example.com";
@@ -48,7 +67,7 @@ describe("semanticSearchTool", () => {
     const { registerSemanticSearchTool } = await import(
       "../../dist/tools/semanticSearchTool.js"
     );
-    await registerSemanticSearchTool(server, {}, {});
+    await registerSemanticSearchTool(server, {});
     const res = await server.handler({ query: "hello", limit: 1 }, {});
     expect(res.method || res.content?.[0]?.json?.method).toBe("lexical");
     const result = res.results
@@ -89,7 +108,7 @@ describe("semanticSearchTool", () => {
     const { registerSemanticSearchTool } = await import(
       "../../dist/tools/semanticSearchTool.js"
     );
-    await registerSemanticSearchTool(server, {}, {});
+    await registerSemanticSearchTool(server, {});
     const res = await server.handler({ fromPath: "A.md", limit: 1 }, {});
     expect(res.method || res.content?.[0]?.json?.method).toBe("lexical");
     const result = res.results
@@ -122,7 +141,7 @@ describe("semanticSearchTool", () => {
     const { registerSemanticSearchTool } = await import(
       "../../dist/tools/semanticSearchTool.js"
     );
-    await registerSemanticSearchTool(server, {}, {});
+    await registerSemanticSearchTool(server, {});
     const res = await server.handler({ fromPath: "A.md", limit: 1 }, {});
     expect(res.method || res.content?.[0]?.json?.method).toBe("files");
     const result = res.results
@@ -166,7 +185,7 @@ describe("semanticSearchTool", () => {
     const { registerSemanticSearchTool } = await import(
       "../../dist/tools/semanticSearchTool.js"
     );
-    await registerSemanticSearchTool(server, {}, {});
+    await registerSemanticSearchTool(server, {});
     const res = await server.handler({ query: "foo", limit: 1 }, {});
     expect(res.method || res.content?.[0]?.json?.method).toBe("files");
     const result = res.results


### PR DESCRIPTION
## Summary
- prefer VaultCacheService for lexical fallback when API config missing
- pass cache service to smartSearch tool and cover with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68beccd93ff4832a97e6dd2ee5f75a6f