### PR TITLE
Improve smart-env vector loading and path matching

### DIFF
--- a/src/utils/resolveSmartEnvDir.ts
+++ b/src/utils/resolveSmartEnvDir.ts
@@ -14,7 +14,12 @@ export function toPosix(p: string): string {
 }
 
 export function samePathEnd(a: string, b: string): boolean {
-  const aa = toPosix(a);
-  const bb = toPosix(b);
+  const norm = (p: string) =>
+    toPosix(p)
+      .normalize("NFD")
+      .replace(/\p{Diacritic}/gu, "")
+      .toLowerCase();
+  const aa = norm(a);
+  const bb = norm(b);
   return aa === bb || aa.endsWith("/" + bb);
 }


### PR DESCRIPTION
## Summary
- Make `samePathEnd` case and accent insensitive
- Broaden vector/path extraction and fallback when parsing smart-env JSON
- Auto-detect smart-env `multi` directory, add caching with TTL/limit and logging

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bfda143964832ab66bc6f496b288e7