### PR TITLE
Rediriger les journaux vers STDERR

### DIFF
--- a/scripts/clean.ts
+++ b/scripts/clean.ts
@@ -64,7 +64,7 @@ const clean = async (): Promise<void> => {
       dirsToClean = args;
     }
 
-    console.log(`Attempting to clean directories: ${dirsToClean.join(", ")}`);
+    console.error(`Attempting to clean directories: ${dirsToClean.join(", ")}`);
 
     const results = await Promise.allSettled(
       dirsToClean.map(async (dir): Promise<CleanResult> => {
@@ -90,9 +90,9 @@ const clean = async (): Promise<void> => {
       if (result.status === "fulfilled") {
         const { dir, status, reason } = result.value;
         if (status === "success") {
-          console.log(`Successfully cleaned directory: ${dir}`);
+          console.error(`Successfully cleaned directory: ${dir}`);
         } else {
-          console.log(`Skipped cleaning directory ${dir}: ${reason}.`);
+          console.error(`Skipped cleaning directory ${dir}: ${reason}.`);
         }
       } else {
         // The error here is the actual error object from the rejected promise

--- a/scripts/fetch-openapi-spec.ts
+++ b/scripts/fetch-openapi-spec.ts
@@ -29,7 +29,7 @@ const urlArg = args[0];
 const outputBaseArg = args[1];
 
 if (helpFlag || !urlArg || !outputBaseArg) {
-  console.log(`
+  console.error(`
 Fetch OpenAPI Specification Script
 
 Usage:
@@ -73,13 +73,13 @@ async function tryFetch(
   url: string,
 ): Promise<{ data: string; contentType: string | null } | null> {
   try {
-    console.log(`Attempting to fetch from: ${url}`);
+    console.error(`Attempting to fetch from: ${url}`);
     const response = await axios.get(url, {
       responseType: "text",
       validateStatus: (status) => status >= 200 && status < 300,
     });
     const contentType = response.headers["content-type"] || null;
-    console.log(
+    console.error(
       `Successfully fetched (Status: ${response.status}, Content-Type: ${contentType || "N/A"})`,
     );
     return { data: response.data, contentType };
@@ -109,28 +109,28 @@ function parseSpec(data: string, contentType: string | null): object | null {
       lowerContentType?.includes("yaml") ||
       lowerContentType?.includes("yml")
     ) {
-      console.log("Parsing content as YAML based on Content-Type...");
+      console.error("Parsing content as YAML based on Content-Type...");
       return yaml.load(data) as object;
     } else if (lowerContentType?.includes("json")) {
-      console.log("Parsing content as JSON based on Content-Type...");
+      console.error("Parsing content as JSON based on Content-Type...");
       return JSON.parse(data);
     } else {
-      console.log(
+      console.error(
         "Content-Type is ambiguous or missing. Attempting to parse as YAML first...",
       );
       try {
         const parsedYaml = yaml.load(data) as object;
         // Basic validation: check if it's a non-null object.
         if (parsedYaml && typeof parsedYaml === "object") {
-          console.log("Successfully parsed as YAML.");
+          console.error("Successfully parsed as YAML.");
           return parsedYaml;
         }
       } catch (yamlError) {
-        console.log("YAML parsing failed. Attempting to parse as JSON...");
+        console.error("YAML parsing failed. Attempting to parse as JSON...");
         try {
           const parsedJson = JSON.parse(data);
           if (parsedJson && typeof parsedJson === "object") {
-            console.log("Successfully parsed as JSON.");
+            console.error("Successfully parsed as JSON.");
             return parsedJson;
           }
         } catch (jsonError) {
@@ -147,7 +147,7 @@ function parseSpec(data: string, contentType: string | null): object | null {
       try {
         const parsedJson = JSON.parse(data);
         if (parsedJson && typeof parsedJson === "object") {
-          console.log(
+          console.error(
             "Successfully parsed as JSON on second attempt for non-object YAML.",
           );
           return parsedJson;
@@ -212,7 +212,7 @@ async function fetchAndProcessSpec(): Promise<void> {
     await fs.access(outputDirAbsolute);
   } catch (error: any) {
     if (error.code === "ENOENT") {
-      console.log(`Output directory not found. Creating: ${outputDirAbsolute}`);
+      console.error(`Output directory not found. Creating: ${outputDirAbsolute}`);
       await fs.mkdir(outputDirAbsolute, { recursive: true });
     } else {
       console.error(
@@ -223,9 +223,9 @@ async function fetchAndProcessSpec(): Promise<void> {
   }
 
   try {
-    console.log(`Saving YAML specification to: ${yamlOutputPath}`);
+    console.error(`Saving YAML specification to: ${yamlOutputPath}`);
     await fs.writeFile(yamlOutputPath, yaml.dump(openapiSpec), "utf8");
-    console.log(`Successfully saved YAML specification.`);
+    console.error(`Successfully saved YAML specification.`);
   } catch (error) {
     console.error(
       `Error saving YAML to ${yamlOutputPath}: ${error instanceof Error ? error.message : String(error)}. Aborting.`,
@@ -234,13 +234,13 @@ async function fetchAndProcessSpec(): Promise<void> {
   }
 
   try {
-    console.log(`Saving JSON specification to: ${jsonOutputPath}`);
+    console.error(`Saving JSON specification to: ${jsonOutputPath}`);
     await fs.writeFile(
       jsonOutputPath,
       JSON.stringify(openapiSpec, null, 2),
       "utf8",
     );
-    console.log(`Successfully saved JSON specification.`);
+    console.error(`Successfully saved JSON specification.`);
   } catch (error) {
     console.error(
       `Error saving JSON to ${jsonOutputPath}: ${error instanceof Error ? error.message : String(error)}. Aborting.`,
@@ -248,7 +248,7 @@ async function fetchAndProcessSpec(): Promise<void> {
     process.exit(1);
   }
 
-  console.log("OpenAPI specification processed and saved successfully.");
+  console.error("OpenAPI specification processed and saved successfully.");
 }
 
 fetchAndProcessSpec();

--- a/scripts/make-executable.ts
+++ b/scripts/make-executable.ts
@@ -50,13 +50,13 @@ const makeExecutable = async (): Promise<void> => {
         : ["dist/index.js"];
 
     if (!isUnix) {
-      console.log(
+      console.error(
         "Skipping chmod operation: Script is running on Windows (not applicable).",
       );
       return;
     }
 
-    console.log(
+    console.error(
       `Attempting to make files executable: ${targetFiles.join(", ")}`,
     );
 
@@ -101,7 +101,7 @@ const makeExecutable = async (): Promise<void> => {
       if (result.status === "fulfilled") {
         const { file, status, reason } = result.value;
         if (status === "success") {
-          console.log(`Successfully made executable: ${file}`);
+          console.error(`Successfully made executable: ${file}`);
         } else if (status === "error") {
           console.error(`Error for ${file}: ${reason}`);
           hasErrors = true;
@@ -123,7 +123,7 @@ const makeExecutable = async (): Promise<void> => {
       );
       // process.exit(1); // Uncomment to exit with error if any file fails
     } else {
-      console.log("All targeted files processed successfully.");
+      console.error("All targeted files processed successfully.");
     }
   } catch (error) {
     console.error(

--- a/scripts/print-smart-env.ts
+++ b/scripts/print-smart-env.ts
@@ -1,9 +1,9 @@
 import { loadSmartEnvVectors } from "../src/search/providers/smartEnvFiles.ts";
 
 const vecs = await loadSmartEnvVectors();
-console.log("vecCount =", vecs.length);
+console.error("vecCount =", vecs.length);
 if (vecs.length)
-  console.log(
+  console.error(
     "sample =",
     vecs.slice(0, 3).map((v) => ({ path: v.path, dim: v.vec.length })),
   );

--- a/scripts/tree.ts
+++ b/scripts/tree.ts
@@ -30,7 +30,7 @@ let maxDepthArg = Infinity;
 
 const args = process.argv.slice(2);
 if (args.includes("--help")) {
-  console.log(`
+  console.error(`
 Generate Tree - Project directory structure visualization tool
 
 Usage:
@@ -205,10 +205,10 @@ const writeTreeToFile = async (): Promise<void> => {
       process.exit(1);
     }
 
-    console.log(`Generating directory tree for project: ${projectName}`);
-    console.log(`Output will be saved to: ${resolvedOutputFile}`);
+    console.error(`Generating directory tree for project: ${projectName}`);
+    console.error(`Output will be saved to: ${resolvedOutputFile}`);
     if (maxDepthArg !== Infinity) {
-      console.log(`Maximum depth set to: ${maxDepthArg}`);
+      console.error(`Maximum depth set to: ${maxDepthArg}`);
     }
 
     const treeContent = await generateTree(projectRoot, ignoreHandler, "", 0); // Pass the Ignore instance
@@ -216,7 +216,7 @@ const writeTreeToFile = async (): Promise<void> => {
     try {
       await fs.access(resolvedOutputDir);
     } catch {
-      console.log(`Output directory not found. Creating: ${resolvedOutputDir}`);
+      console.error(`Output directory not found. Creating: ${resolvedOutputDir}`);
       await fs.mkdir(resolvedOutputDir, { recursive: true });
     }
 
@@ -234,7 +234,7 @@ const writeTreeToFile = async (): Promise<void> => {
     const finalContent = fileHeader + depthInfo + treeBlock + fileFooter;
 
     await fs.writeFile(resolvedOutputFile, finalContent);
-    console.log(
+    console.error(
       `Successfully generated tree structure in: ${resolvedOutputFile}`,
     );
   } catch (error) {

--- a/scripts/try-smart-search.ts
+++ b/scripts/try-smart-search.ts
@@ -15,4 +15,4 @@ if (!(query || fromPath)) {
   process.exit(2);
 }
 const res = await smartSearch({ query, fromPath, limit });
-console.log(JSON.stringify(res, null, 2));
+process.stdout.write(JSON.stringify(res, null, 2) + "\n");

--- a/src/mcp-server/transports/httpTransport.ts
+++ b/src/mcp-server/transports/httpTransport.ts
@@ -114,7 +114,7 @@ function startHttpServerWithRetry(
               address: serverAddress,
             });
             if (process.stdout.isTTY) {
-              console.log(`\n🚀 MCP Server running at: ${serverAddress}\n`);
+              console.error(`\n🚀 MCP Server running at: ${serverAddress}\n`);
             }
           },
         );

--- a/src/mcp-server/transports/stdioTransport.ts
+++ b/src/mcp-server/transports/stdioTransport.ts
@@ -68,7 +68,7 @@ export async function connectStdioTransport(
       operationContext,
     );
     if (process.stdout.isTTY) {
-      console.log(
+      console.error(
         `\n🚀 MCP Server running in STDIO mode.\n   (MCP Spec: 2025-03-26 Stdio Transport)\n`,
       );
     }

--- a/src/utils/parsing/jsonParser.ts
+++ b/src/utils/parsing/jsonParser.ts
@@ -148,7 +148,7 @@ class JsonParser {
  * const context: RequestContext = requestContextService.createRequestContext({ operation: 'MyOperation' });
  * try {
  *   const data = jsonParser.parse('<think>Thinking...</think>{"key": "value", "arr": [1,', Allow.ALL, context);
- *   console.log(data); // Output: { key: "value", arr: [ 1 ] }
+ *   console.error(data); // Output: { key: "value", arr: [ 1 ] }
  * } catch (e) {
  *   console.error("Parsing failed:", e);
  * }


### PR DESCRIPTION
## Résumé
- Remplacer les `console.log` des scripts utilitaires par `console.error` ou `process.stdout.write`
- Utiliser `console.error` dans les transports HTTP et STDIO du serveur MCP
- Nettoyer les exemples de documentation pour éviter `console.log`

## Test
- `npm test`
- `OBSIDIAN_API_KEY=test MCP_TRANSPORT_TYPE=stdio node dist/index.js >/tmp/server_stdout.log 2>/tmp/server_stderr.log <<'EOF'
{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"clientInfo":{"name":"test","version":"1.0"},"capabilities":{}}}
{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}
{"jsonrpc":"2.0","id":2,"method":"shutdown","params":{}}
{"jsonrpc":"2.0","method":"exit","params":{}}
EOF
wc -c /tmp/server_stdout.log /tmp/server_stderr.log`


------
https://chatgpt.com/codex/tasks/task_e_68bfda1b93a4832a8cab612504017d0b