### PR TITLE
Ajout de la passerelle de recherche Smart Connections

### DIFF
--- a/src/search/providers/obsidianPluginSmart.ts
+++ b/src/search/providers/obsidianPluginSmart.ts
@@ -1,0 +1,83 @@
+import { toPosix } from "../../utils/resolveSmartEnvDir.js";
+
+export type PluginSmartInput = {
+  query?: string;
+  fromPath?: string;
+  limit?: number;
+};
+export type PluginSmartResult = {
+  path: string;
+  score?: number;
+  preview?: string;
+};
+export type PluginSmartResponse = {
+  results: PluginSmartResult[];
+};
+
+const PLUGIN_TIMEOUT_MS = 15000;
+const PLUGIN_RETRIES = 2;
+
+export async function obsidianPluginSmart(
+  input: PluginSmartInput,
+): Promise<PluginSmartResponse | null> {
+  const base = process.env.OBSIDIAN_BASE_URL;
+  const key = process.env.OBSIDIAN_API_KEY;
+  if (!base || !key || typeof fetch !== "function") return null;
+
+  const url = `${base.replace(/\/+$/, "")}/search/smart`;
+  const payload: any = {
+    query: input.query ?? undefined,
+    fromPath: input.fromPath ?? undefined,
+    limit: input.limit ?? undefined,
+  };
+
+  const fetchFn: typeof fetch = fetch;
+  let lastErr: any = null;
+  for (let attempt = 0; attempt <= PLUGIN_RETRIES; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), PLUGIN_TIMEOUT_MS);
+    try {
+      const res = await fetchFn(url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${key}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+
+      if (res.status === 401 || res.status === 403 || res.status === 404)
+        return null;
+
+      if (res.status >= 500 && res.status < 600) {
+        if (attempt < PLUGIN_RETRIES) continue;
+        throw new Error(`HTTP ${res.status}`);
+      }
+
+      if (!res.ok) return null;
+
+      const body = await res.json().catch(() => ({}));
+      const raw = Array.isArray(body?.results)
+        ? body.results
+        : Array.isArray(body)
+          ? body
+          : [];
+      const results = raw
+        .map((r: any) => ({
+          path: typeof r?.path === "string" ? toPosix(r.path) : null,
+          score: typeof r?.score === "number" ? r.score : undefined,
+          preview: typeof r?.preview === "string" ? r.preview : undefined,
+        }))
+        .filter((r: any) => r.path);
+      return { results };
+    } catch (err) {
+      clearTimeout(timer);
+      lastErr = err;
+      if (attempt >= PLUGIN_RETRIES) throw err;
+    }
+  }
+  if (lastErr) throw lastErr;
+  return null;
+}

--- a/src/search/smartSearch.ts
+++ b/src/search/smartSearch.ts
@@ -3,6 +3,7 @@ import {
   cosineTopK,
   NoteVec,
 } from "./providers/smartEnvFiles.js";
+import { obsidianPluginSmart } from "./providers/obsidianPluginSmart.js";
 import {
   resolveSmartEnvDir,
   toPosix,
@@ -16,15 +17,8 @@ export type SmartSearchInput = {
 };
 export type SmartSearchOutput = {
   method: "plugin" | "files" | "lexical";
-  results: { path: string; score: number }[];
+  results: { path: string; score?: number; preview?: string }[];
 };
-
-// ---- passerelle plugin optionnelle (aucune API officielle pour l’instant) ----
-async function viaPlugin(
-  _input: SmartSearchInput,
-): Promise<SmartSearchOutput | null> {
-  return null;
-}
 
 // ---- encodage local de requête (xenova) ----
 let _pipePromise: Promise<any> | null = null;
@@ -151,13 +145,13 @@ export async function smartSearch(
   const wantQuery = !!query;
   const wantNeighbors = !!fromPath;
 
-  // 1) mode plugin (noop)
+  // 1) mode plugin (optional bridge)
   try {
     if (
       process.env.SMART_SEARCH_MODE === "plugin" &&
       process.env.SMART_CONNECTIONS_API
     ) {
-      const via = await viaPlugin({
+      const via = await obsidianPluginSmart({
         query,
         fromPath: fromPath || undefined,
         limit,

--- a/src/tools/semanticSearchTool.ts
+++ b/src/tools/semanticSearchTool.ts
@@ -4,7 +4,7 @@ import { smartSearch } from "../search/smartSearch.js";
 export type Input = { query?: string; fromPath?: string; limit?: number };
 export type Output = {
   method: "plugin" | "files" | "lexical";
-  results: { path: string; score: number }[];
+  results: { path: string; score?: number; preview?: string }[];
 };
 
 const tool = {

--- a/tests/search/obsidianPluginSmart.test.js
+++ b/tests/search/obsidianPluginSmart.test.js
@@ -1,0 +1,74 @@
+import { jest } from "@jest/globals";
+
+const modPath = "../../dist/search/providers/obsidianPluginSmart.js";
+
+beforeEach(() => {
+  process.env.OBSIDIAN_BASE_URL = "http://x";
+  process.env.OBSIDIAN_API_KEY = "k";
+});
+
+afterEach(() => {
+  delete process.env.OBSIDIAN_BASE_URL;
+  delete process.env.OBSIDIAN_API_KEY;
+  const gf = global.fetch;
+  if (gf && typeof gf === "function" && typeof gf.mockReset === "function") {
+    gf.mockReset();
+  }
+  // @ts-ignore
+  delete global.fetch;
+});
+
+test("success", async () => {
+  global.fetch = jest.fn(async () => ({
+    ok: true,
+    json: async () => ({
+      results: [{ path: "A.md", score: 0.9, preview: "foo" }],
+    }),
+  }));
+  const { obsidianPluginSmart } = await import(modPath);
+  const res = await obsidianPluginSmart({ query: "q" });
+  expect(res).toEqual({
+    results: [{ path: "A.md", score: 0.9, preview: "foo" }],
+  });
+  expect(global.fetch).toHaveBeenCalledTimes(1);
+});
+
+test.each([401, 403, 404])("%s returns null", async (status) => {
+  global.fetch = jest.fn(async () => ({ status }));
+  const { obsidianPluginSmart } = await import(modPath);
+  const res = await obsidianPluginSmart({ query: "q" });
+  expect(res).toBeNull();
+  expect(global.fetch).toHaveBeenCalledTimes(1);
+});
+
+test("5xx retries then fails", async () => {
+  global.fetch = jest.fn(async () => ({ status: 500 }));
+  const { obsidianPluginSmart } = await import(modPath);
+  await expect(obsidianPluginSmart({ query: "q" })).rejects.toThrow();
+  expect(global.fetch).toHaveBeenCalledTimes(3);
+});
+
+test("timeout triggers abort", async () => {
+  jest.useFakeTimers();
+  global.fetch = jest.fn(
+    (url, opts) =>
+      new Promise((_resolve, reject) => {
+        opts.signal.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          // @ts-ignore
+          err.name = "AbortError";
+          reject(err);
+        });
+      }),
+  );
+  const { obsidianPluginSmart } = await import(modPath);
+  const p = obsidianPluginSmart({ query: "q" });
+  jest.advanceTimersByTime(15000);
+  await Promise.resolve();
+  jest.advanceTimersByTime(15000);
+  await Promise.resolve();
+  jest.advanceTimersByTime(15000);
+  await expect(p).rejects.toThrow();
+  expect(global.fetch).toHaveBeenCalledTimes(3);
+  jest.useRealTimers();
+});

--- a/tests/search/smartSearch.test.js
+++ b/tests/search/smartSearch.test.js
@@ -2,6 +2,7 @@ import { jest } from "@jest/globals";
 
 afterEach(() => {
   delete process.env.SMART_SEARCH_MODE;
+  delete process.env.SMART_CONNECTIONS_API;
   delete process.env.OBSIDIAN_BASE_URL;
   delete process.env.OBSIDIAN_API_KEY;
   const gf = global.fetch;
@@ -60,4 +61,96 @@ test("lexical fallback never throws", async () => {
     method: "lexical",
     results: [],
   });
+});
+
+test("plugin success returns plugin results", async () => {
+  process.env.SMART_SEARCH_MODE = "plugin";
+  process.env.SMART_CONNECTIONS_API = "1";
+  process.env.OBSIDIAN_BASE_URL = "http://x";
+  process.env.OBSIDIAN_API_KEY = "y";
+  global.fetch = jest.fn(async (url) => {
+    if (url === "http://x/search/smart") {
+      return {
+        ok: true,
+        json: async () => ({ results: [{ path: "Note.md", score: 0.5 }] }),
+      };
+    }
+    return { ok: true, json: async () => ({ files: [] }) };
+  });
+  const { smartSearch } = await import("../../dist/search/smartSearch.js");
+  const res = await smartSearch({ query: "hello" });
+  expect(res).toEqual({
+    method: "plugin",
+    results: [{ path: "Note.md", score: 0.5 }],
+  });
+  expect(global.fetch).toHaveBeenCalledTimes(1);
+});
+
+test.each([401, 403, 404])(
+  "plugin %s triggers lexical fallback",
+  async (status) => {
+    process.env.SMART_SEARCH_MODE = "plugin";
+    process.env.SMART_CONNECTIONS_API = "1";
+    process.env.OBSIDIAN_BASE_URL = "http://x";
+    process.env.OBSIDIAN_API_KEY = "y";
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ status })
+      .mockResolvedValue({ ok: true, json: async () => ({ files: [] }) });
+    const { smartSearch } = await import("../../dist/search/smartSearch.js");
+    const res = await smartSearch({ query: "hello" });
+    expect(res.method).toBe("lexical");
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  },
+);
+
+test("plugin 5xx retries then falls back", async () => {
+  process.env.SMART_SEARCH_MODE = "plugin";
+  process.env.SMART_CONNECTIONS_API = "1";
+  process.env.OBSIDIAN_BASE_URL = "http://x";
+  process.env.OBSIDIAN_API_KEY = "y";
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ status: 500 })
+    .mockResolvedValueOnce({ status: 502 })
+    .mockResolvedValueOnce({ status: 503 })
+    .mockResolvedValue({ ok: true, json: async () => ({ files: [] }) });
+  const { smartSearch } = await import("../../dist/search/smartSearch.js");
+  const res = await smartSearch({ query: "hello" });
+  expect(res.method).toBe("lexical");
+  expect(global.fetch).toHaveBeenCalledTimes(4);
+});
+
+test("plugin timeout falls back to lexical", async () => {
+  jest.useFakeTimers();
+  process.env.SMART_SEARCH_MODE = "plugin";
+  process.env.SMART_CONNECTIONS_API = "1";
+  process.env.OBSIDIAN_BASE_URL = "http://x";
+  process.env.OBSIDIAN_API_KEY = "y";
+  let call = 0;
+  global.fetch = jest.fn((url, opts) => {
+    if (url === "http://x/search/smart") {
+      call++;
+      return new Promise((_resolve, reject) => {
+        opts.signal.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          // @ts-ignore
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({ files: [] }) });
+  });
+  const { smartSearch } = await import("../../dist/search/smartSearch.js");
+  const p = smartSearch({ query: "hello" });
+  jest.advanceTimersByTime(15000);
+  await Promise.resolve();
+  jest.advanceTimersByTime(15000);
+  await Promise.resolve();
+  jest.advanceTimersByTime(15000);
+  const res = await p;
+  expect(res.method).toBe("lexical");
+  expect(global.fetch).toHaveBeenCalledTimes(4);
+  jest.useRealTimers();
 });


### PR DESCRIPTION
## Résumé
- intègre un fournisseur `obsidianPluginSmart` qui interroge l’API `/search/smart` avec authentification, timeout de 15 s et deux retries
- tente la recherche via le plugin avant les embeddings Xenova et expose score/aperçu optionnels
- étend l’outil `smart-search` et ajoute une batterie de tests couvrant succès, erreurs 4xx/5xx, timeout et repli

## Tests
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfda1d9858832abe019471e811ac40