### PR TITLE
docs: exemples de sortie smart search

### DIFF
--- a/docs/smart-search-output.md
+++ b/docs/smart-search-output.md
@@ -1,0 +1,48 @@
+# Exemples de sorties Smart Search
+
+Après `npm run build` :
+
+## 1. `node dist/scripts/print-smart-env.js`
+
+```
+vecCount = 3
+sample = [
+  { path: 'Alpha.md', dim: 384 },
+  { path: 'Beta.md', dim: 384 },
+  { path: 'Gamma.md', dim: 384 }
+]
+```
+
+## 2. `node dist/scripts/try-smart-search.js --fromPath "Alpha.md" --limit 10`
+
+```
+{
+  "method": "files",
+  "results": [
+    { "path": "Beta.md", "score": 0.7391 },
+    { "path": "Gamma.md", "score": 0.7356 }
+  ]
+}
+```
+
+La note ancre `Alpha.md` est absente des résultats.
+
+## 3. `node dist/scripts/try-smart-search.js --query "diagnostic mcp obsidian" --limit 10`
+
+```
+{
+  "method": "lexical",
+  "results": []
+}
+```
+
+_Comportement attendu_: `method` devrait valoir `files` avec l'encodeur `TaylorAI/bge-micro-v2` (xenova, ~384 dimensions). L'absence de modèle local a provoqué un repli lexical.
+
+## 4. `SMART_SEARCH_MODE=plugin node dist/scripts/try-smart-search.js --query "mcp" --limit 5`
+
+```
+{
+  "method": "lexical",
+  "results": []
+}
+```


### PR DESCRIPTION
## Résumé
- ajoute un exemple documenté des sorties des scripts `print-smart-env` et `try-smart-search`
- montre l’exclusion de la note ancre et le repli lexical lorsque l’encodeur n’est pas disponible

## Tests
- `npm run lint`
- `npm test` *(échoue : "semanticSearchTool returns neighbors from .smart-env when fromPath provided" attendu method=files, obtenu=lexical)*
- `npm run build`
- `node dist/scripts/print-smart-env.js` *(via ts-node)
- `node dist/scripts/try-smart-search.js --fromPath "Alpha.md" --limit 10` *(via ts-node)
- `node dist/scripts/try-smart-search.js --query "diagnostic mcp obsidian" --limit 10` *(via ts-node)
- `SMART_SEARCH_MODE=plugin node dist/scripts/try-smart-search.js --query "mcp" --limit 5` *(via ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_68bfda2121e0832aaec0fb197631444c