### PR TITLE
Fix smart search test paths and plugin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,14 @@ smart-search {"fromPath":"/mnt/f/.../Note.md","limit":10}
 ### Variables d'environnement
 
 #### Plugin
+
 - `OBSIDIAN_BASE_URL` : URL de l'API REST locale (défaut `http://127.0.0.1:27123`).
 - `OBSIDIAN_API_KEY` : clé issue du plugin Local REST API.
 - `PLUGIN_TIMEOUT_MS` : délai maximal d'attente des appels au plugin (ms).
 - `PLUGIN_RETRIES` : nombre de tentatives en cas d'échec.
 
 #### Embeddings
+
 - `SMART_SEARCH_MODE` : `auto` (défaut, plugin ➜ files ➜ lexical), `plugin`, `files` ou `lexical`.
 - `SMART_ENV_DIR` : chemin vers le dossier `.smart-env` de votre vault (ex. `/chemin/vers/vault/.smart-env`). En mode `files`, seule la recherche de notes similaires via `fromPath` est possible.
 - `SMART_ENV_CACHE_TTL_MS` : durée de vie en cache des vecteurs `.ajson` (ms, défaut 60000).
@@ -82,6 +84,7 @@ smart-search {"fromPath":"/mnt/f/.../Note.md","limit":10}
 - `SMART_CONNECTIONS_API` : URL du service Smart Connections si disponible.
 
 #### Xenova
+
 - `ENABLE_QUERY_EMBEDDING` : `true` pour encoder localement les requêtes.
 - `QUERY_EMBEDDER` : `xenova` (valeur par défaut).
 - `TRANSFORMERS_CACHE` : chemin optionnel du cache des modèles.
@@ -89,6 +92,7 @@ smart-search {"fromPath":"/mnt/f/.../Note.md","limit":10}
 - `EMBED_TIMEOUT_MS` : délai maximal pour chaque encodage (ms).
 
 L'outil `create-base` produit un YAML minimal centré sur `views:` et peut définir `properties` (objets de configuration comme `displayName`) et `formulas`.
+
 ## Sécurité & Confidentialité
 
 Toutes les opérations se font en local. Aucune donnée n'est envoyée vers l'extérieur. La clé API n'est jamais journalisée.

--- a/scripts/fetch-openapi-spec.ts
+++ b/scripts/fetch-openapi-spec.ts
@@ -212,7 +212,9 @@ async function fetchAndProcessSpec(): Promise<void> {
     await fs.access(outputDirAbsolute);
   } catch (error: any) {
     if (error.code === "ENOENT") {
-      console.error(`Output directory not found. Creating: ${outputDirAbsolute}`);
+      console.error(
+        `Output directory not found. Creating: ${outputDirAbsolute}`,
+      );
       await fs.mkdir(outputDirAbsolute, { recursive: true });
     } else {
       console.error(

--- a/scripts/tree.ts
+++ b/scripts/tree.ts
@@ -216,7 +216,9 @@ const writeTreeToFile = async (): Promise<void> => {
     try {
       await fs.access(resolvedOutputDir);
     } catch {
-      console.error(`Output directory not found. Creating: ${resolvedOutputDir}`);
+      console.error(
+        `Output directory not found. Creating: ${resolvedOutputDir}`,
+      );
       await fs.mkdir(resolvedOutputDir, { recursive: true });
     }
 

--- a/src/search/embedders/xenovaEmbedder.ts
+++ b/src/search/embedders/xenovaEmbedder.ts
@@ -69,4 +69,3 @@ export async function warmup(): Promise<void> {
     // Ignorer les erreurs de warmup
   }
 }
-

--- a/tests/search/obsidianPluginSmart.test.js
+++ b/tests/search/obsidianPluginSmart.test.js
@@ -1,6 +1,6 @@
 import { jest } from "@jest/globals";
 
-const modPath = "../../dist/search/providers/obsidianPluginSmart.js";
+const modPath = "../../dist/src/search/providers/obsidianPluginSmart.js";
 
 beforeEach(() => {
   process.env.OBSIDIAN_BASE_URL = "http://x";


### PR DESCRIPTION
## Summary
- Use built files from `dist/src` in search tests
- Update smart search tests to rely on `SMART_CONNECTIONS_API` and single plugin attempt
- Format repository with Prettier so lint passes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bff127a1cc832aa119e9fb71e7814d