### PR TITLE
build: configure bases bridge bundling

### DIFF
--- a/plugins/obsidian-bases-bridge/README.md
+++ b/plugins/obsidian-bases-bridge/README.md
@@ -1,0 +1,22 @@
+# Obsidian Bases Bridge
+
+Plugin compagnon pour **obsidian-mcp-server**. Il ajoute une vue headless « Bridge (Headless) » et étend le plugin **Obsidian Local REST API** avec des routes spécialisées pour les fichiers `.base`. Les agents MCP peuvent ainsi interroger les Bases via REST, éditer les propriétés des notes (frontmatter) et créer/mettre à jour les fichiers `.base` (YAML).
+
+## Installation rapide
+
+1. Copier ce dossier dans `.obsidian/plugins/`.
+2. Lancer Obsidian → *Settings → Community plugins* → activer **Bases Bridge (REST)**.
+3. Vérifier que le plugin **Local REST API** est actif (≥ 2.5) et que le coffre est autorisé.
+4. Dans chaque base ciblée, activer la vue « Bridge (Headless) » pour profiter des valeurs évaluées par l’engine.
+
+## Endpoints exposés
+
+- `GET /bases`
+- `GET /bases/:id/schema`
+- `POST /bases/:id/query`
+- `POST /bases/:id/upsert`
+- `POST /bases`
+- `GET /bases/:id/config`
+- `PUT /bases/:id/config`
+
+Les routes héritent de l’authentification Bearer + TLS local du plugin REST.

--- a/plugins/obsidian-bases-bridge/esbuild.config.mjs
+++ b/plugins/obsidian-bases-bridge/esbuild.config.mjs
@@ -1,0 +1,76 @@
+import esbuild from "esbuild";
+import { copyFileSync, mkdirSync, existsSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const banner = "/* Obsidian Bases Bridge - build via esbuild */";
+const entryFile = "src/main.ts";
+const outdir = "build";
+const outfile = join(outdir, "main.js");
+const isWatch = process.argv.includes("--watch");
+
+const buildOptions = {
+  entryPoints: [entryFile],
+  bundle: true,
+  sourcemap: "inline",
+  target: "es2018",
+  format: "cjs",
+  platform: "browser",
+  outfile,
+  banner: { js: banner },
+  external: ["obsidian", "node:http", "node:url"],
+  minify: false,
+  logLevel: "info",
+};
+
+function postBuild() {
+  mkdirSync(outdir, { recursive: true });
+
+  const manifestPath = "manifest.json";
+  const manifestOut = join(outdir, "manifest.json");
+  if (existsSync(manifestPath)) {
+    const m = JSON.parse(readFileSync(manifestPath, "utf8"));
+    m.main = "main.js";
+    writeFileSync(manifestOut, JSON.stringify(m, null, 2));
+  }
+
+  if (existsSync("styles.css")) {
+    copyFileSync("styles.css", join(outdir, "styles.css"));
+  }
+}
+
+async function build() {
+  if (isWatch) {
+    const ctx = await esbuild.context({
+      ...buildOptions,
+      plugins: [
+        {
+          name: "obsidian-bases-bridge-post-build",
+          setup(build) {
+            build.onEnd((result) => {
+              if (result.errors.length === 0) {
+                try {
+                  postBuild();
+                  console.log(`Rebuilt → ${outfile}`);
+                } catch (error) {
+                  console.error(error);
+                }
+              }
+            });
+          },
+        },
+      ],
+    });
+
+    await ctx.watch();
+    console.log("Watching for changes…");
+  } else {
+    await esbuild.build(buildOptions);
+    postBuild();
+    console.log(`Built → ${outfile}`);
+  }
+}
+
+build().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/plugins/obsidian-bases-bridge/manifest.json
+++ b/plugins/obsidian-bases-bridge/manifest.json
@@ -1,0 +1,10 @@
+{
+  "id": "obsidian-bases-bridge",
+  "name": "Bases Bridge (REST)",
+  "version": "0.1.0",
+  "minAppVersion": "1.6.0",
+  "author": "Codex Automation",
+  "authorUrl": "https://github.com/cyanheads/obsidian-mcp-server",
+  "description": "Expose les Bases (.base) d'Obsidian via un bridge REST/Local REST API et une vue headless pour les agents MCP.",
+  "isDesktopOnly": false
+}

--- a/plugins/obsidian-bases-bridge/package.json
+++ b/plugins/obsidian-bases-bridge/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "obsidian-bases-bridge",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node esbuild.config.mjs",
+    "dev": "node esbuild.config.mjs --watch"
+  },
+  "devDependencies": {
+    "esbuild": "^0.24.0"
+  }
+}

--- a/plugins/obsidian-bases-bridge/src/main.ts
+++ b/plugins/obsidian-bases-bridge/src/main.ts
@@ -1,0 +1,887 @@
+/*
+ * Obsidian Bases Bridge plugin.
+ *
+ * This plugin exposes the core Bases features (query, schema, upsert, config)
+ * over HTTP by extending the Obsidian Local REST API plugin. It also registers
+ * a headless Bases view to reuse the built-in engine whenever possible while
+ * keeping a disk-based fallback for environments where the view is inactive.
+ */
+
+import { App, Plugin, TFile, normalizePath, parseYaml, stringifyYaml } from "obsidian";
+import { createServer, IncomingMessage, Server, ServerResponse } from "node:http";
+import { URL } from "node:url";
+
+// ---------------------------------------------------------------------------
+// Type helpers
+// ---------------------------------------------------------------------------
+
+type SortDirection = "asc" | "desc";
+
+type AdditionalFilter = {
+  eq?: Record<string, unknown>;
+  in?: Record<string, unknown[]>;
+  regex?: Record<string, string>;
+  and?: AdditionalFilter[];
+  or?: AdditionalFilter[];
+  not?: AdditionalFilter;
+};
+
+interface QueryPayload {
+  view?: string;
+  filter?: AdditionalFilter;
+  sort?: Array<{ prop: string; dir?: SortDirection }>;
+  limit?: number;
+  page?: number;
+  evaluate?: boolean;
+}
+
+interface UpsertOperation {
+  file: string;
+  set?: Record<string, unknown>;
+  unset?: string[];
+  expected_mtime?: number;
+}
+
+interface UpsertPayload {
+  operations: UpsertOperation[];
+  continueOnError?: boolean;
+}
+
+interface BaseCreatePayload {
+  path: string;
+  spec: Record<string, unknown>;
+  overwrite?: boolean;
+  validateOnly?: boolean;
+}
+
+interface BaseConfigPayload {
+  yaml?: string;
+  json?: Record<string, unknown>;
+  validateOnly?: boolean;
+}
+
+interface BridgeRow {
+  file: { path: string; name: string };
+  props: Record<string, unknown>;
+  computed: Record<string, unknown>;
+}
+
+interface EngineCacheEntry {
+  baseId: string;
+  rows: BridgeRow[];
+  order: string[];
+  evaluate: boolean;
+  timestamp: number;
+}
+
+interface BaseDefinition {
+  filters?: Record<string, unknown> | undefined;
+  formulas?: Record<string, unknown> | undefined;
+  properties?: Record<string, any> | undefined;
+  views?: Array<Record<string, any>> | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Headless view implementation (best-effort, resilient to API changes)
+// ---------------------------------------------------------------------------
+
+class HeadlessBridgeView {
+  private controller: any;
+  private cache: Map<string, EngineCacheEntry>;
+
+  constructor(controller: any, cache: Map<string, EngineCacheEntry>) {
+    this.controller = controller;
+    this.cache = cache;
+    // Ensure the container stays empty (headless view)
+    if (controller?.containerEl) {
+      controller.containerEl.empty?.();
+      controller.containerEl.toggleClass?.("bases-bridge-hidden", true);
+    }
+  }
+
+  onDataUpdated(): void {
+    try {
+      const baseFile: TFile | undefined = this.controller?.baseFile;
+      const baseId = baseFile?.path;
+      if (!baseId) {
+        return;
+      }
+
+      const order: string[] =
+        this.controller?.config?.getOrder?.() ??
+        this.controller?.config?.getSortOrder?.() ??
+        [];
+
+      const entries: any[] =
+        this.controller?.data?.entries ??
+        this.controller?.data?.rows ??
+        this.controller?.rows ??
+        [];
+
+      const rows: BridgeRow[] = entries.map((entry: any) => {
+        const file: { path: string; name: string } = {
+          path: entry?.file?.path ?? entry?.path ?? entry?.getFile?.()?.path ?? "",
+          name:
+            entry?.file?.name ??
+            entry?.file?.basename ??
+            entry?.getFile?.()?.name ??
+            entry?.getFile?.()?.basename ??
+            "",
+        };
+
+        const props: Record<string, unknown> = {};
+        const computed: Record<string, unknown> = {};
+        const propertyKeys: string[] =
+          this.controller?.config?.getVisibleColumns?.() ?? order ?? [];
+
+        if (typeof entry?.getValue === "function") {
+          for (const key of propertyKeys) {
+            try {
+              const value = entry.getValue(key);
+              if (key.startsWith("file.")) {
+                computed[key] = normalizeEngineValue(value);
+              } else {
+                props[key] = normalizeEngineValue(value);
+              }
+            } catch (error) {
+              console.error("[Bases Bridge] Failed to read value", key, error);
+            }
+          }
+        } else if (entry?.values) {
+          for (const key of Object.keys(entry.values)) {
+            const value = entry.values[key];
+            if (key.startsWith("file.")) {
+              computed[key] = normalizeEngineValue(value);
+            } else {
+              props[key] = normalizeEngineValue(value);
+            }
+          }
+        }
+
+        return { file, props, computed };
+      });
+
+      this.cache.set(baseId, {
+        baseId,
+        rows,
+        order,
+        evaluate: true,
+        timestamp: Date.now(),
+      });
+    } catch (error) {
+      console.error("[Bases Bridge] Failed to refresh engine dataset", error);
+    }
+  }
+
+  onunload(): void {
+    // Nothing to clean up explicitly; the parent plugin clears cache entries.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin main class
+// ---------------------------------------------------------------------------
+
+export default class BasesBridgePlugin extends Plugin {
+  private engineCache = new Map<string, EngineCacheEntry>();
+  private microServer: Server | null = null;
+  private readonly microServerPort = 3117;
+
+  async onload(): Promise<void> {
+    console.info("[Bases Bridge] Initialising plugin");
+    this.registerHeadlessView();
+    await this.registerRestExtension();
+  }
+
+  async onunload(): Promise<void> {
+    this.engineCache.clear();
+    if (this.microServer) {
+      this.microServer.close();
+      this.microServer = null;
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Headless view registration
+  // -----------------------------------------------------------------------
+
+  private registerHeadlessView(): void {
+    const register = (this as unknown as { registerBasesView?: (...args: any[]) => void }).registerBasesView;
+    if (typeof register !== "function") {
+      console.warn("[Bases Bridge] registerBasesView API unavailable. Engine mode disabled.");
+      return;
+    }
+
+    try {
+      register.call(this, "bases-bridge-headless", {
+        name: "Bridge (Headless)",
+        icon: "plug-zap",
+        factory: (controller: any, containerEl: HTMLElement) => {
+          containerEl.empty?.();
+          containerEl.toggleClass?.("bases-bridge-hidden", true);
+          const view = new HeadlessBridgeView(controller, this.engineCache);
+          this.register(() => view.onunload());
+          return view;
+        },
+      });
+      console.info("[Bases Bridge] Headless view registered");
+    } catch (error) {
+      console.error("[Bases Bridge] Failed to register headless view", error);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // REST registration (extension + fallback microserver)
+  // -----------------------------------------------------------------------
+
+  private async registerRestExtension(): Promise<void> {
+    const restPlugin: any = (this.app as App & { plugins: any }).plugins?.getPlugin?.(
+      "obsidian-local-rest-api",
+    );
+
+    if (restPlugin?.getPublicApi) {
+      try {
+        const api = restPlugin.getPublicApi(this.manifest);
+        const baseRoute = api.addRoute("/bases");
+        baseRoute.get(async (req: any, res: any) => {
+          try {
+            const bases = await this.handleListBases();
+            res.json({ bases });
+          } catch (error) {
+            this.returnExpressError(res, error);
+          }
+        });
+        baseRoute.post(async (req: any, res: any) => {
+          await this.handleCreateBaseExpress(req, res);
+        });
+
+        api
+          .addRoute("/bases/:id/schema")
+          .get(async (req: any, res: any) => {
+            await this.handleGetSchemaExpress(req, res);
+          });
+
+        api
+          .addRoute("/bases/:id/query")
+          .post(async (req: any, res: any) => {
+            await this.handleQueryExpress(req, res);
+          });
+
+        api
+          .addRoute("/bases/:id/upsert")
+          .post(async (req: any, res: any) => {
+            await this.handleUpsertExpress(req, res);
+          });
+
+        api
+          .addRoute("/bases/:id/config")
+          .get(async (req: any, res: any) => {
+            await this.handleGetConfigExpress(req, res);
+          })
+          .put(async (req: any, res: any) => {
+            await this.handlePutConfigExpress(req, res);
+          });
+
+        console.info("[Bases Bridge] Routes registered via Local REST API extension");
+        return;
+      } catch (error) {
+        console.error("[Bases Bridge] Failed to register REST extension", error);
+      }
+    }
+
+    // Fallback micro-server
+    this.startMicroServer();
+  }
+
+  private startMicroServer(): void {
+    if (this.microServer) {
+      return;
+    }
+
+    this.microServer = createServer(async (req, res) => {
+      try {
+        await this.routeMicroRequest(req, res);
+      } catch (error) {
+        this.sendMicroError(res, error);
+      }
+    });
+
+    this.microServer.listen(this.microServerPort, "127.0.0.1", () => {
+      console.warn(
+        `[Bases Bridge] Using fallback HTTP server on http://127.0.0.1:${this.microServerPort}/ (extension API indisponible)`,
+      );
+    });
+  }
+
+  private async routeMicroRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (!req.url || !req.method) {
+      this.sendMicroError(res, new Error("Invalid request"));
+      return;
+    }
+
+    const url = new URL(req.url, `http://${req.headers.host ?? "127.0.0.1"}`);
+    const path = url.pathname.replace(/\/$/, "");
+    const method = req.method.toUpperCase();
+
+    // CORS (localhost uniquement)
+    res.setHeader("Access-Control-Allow-Origin", "http://localhost");
+    res.setHeader("Access-Control-Allow-Methods", "GET,POST,PUT,OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+
+    if (method === "OPTIONS") {
+      res.writeHead(204).end();
+      return;
+    }
+
+    const body = await readBody(req);
+
+    if (method === "GET" && path === "/bases") {
+      const bases = await this.handleListBases();
+      this.writeJson(res, { bases });
+      return;
+    }
+
+    const schemaMatch = path.match(/^\/bases\/(.+)\/schema$/);
+    const queryMatch = path.match(/^\/bases\/(.+)\/query$/);
+    const upsertMatch = path.match(/^\/bases\/(.+)\/upsert$/);
+    const configMatch = path.match(/^\/bases\/(.+)\/config$/);
+
+    if (schemaMatch && method === "GET") {
+      const baseId = decodeURIComponent(schemaMatch[1]);
+      const schema = await this.readBaseSchema(baseId);
+      this.writeJson(res, schema);
+      return;
+    }
+
+    if (queryMatch && method === "POST") {
+      const baseId = decodeURIComponent(queryMatch[1]);
+      const payload = (body ? JSON.parse(body) : {}) as QueryPayload;
+      const result = await this.executeQuery(baseId, payload);
+      this.writeJson(res, result);
+      return;
+    }
+
+    if (upsertMatch && method === "POST") {
+      const baseId = decodeURIComponent(upsertMatch[1]);
+      const payload = (body ? JSON.parse(body) : {}) as UpsertPayload;
+      const result = await this.performUpsert(baseId, payload);
+      this.writeJson(res, result, 200);
+      return;
+    }
+
+    if (method === "POST" && path === "/bases") {
+      const payload = (body ? JSON.parse(body) : {}) as BaseCreatePayload;
+      const result = await this.createBaseFile(payload);
+      this.writeJson(res, result, 201);
+      return;
+    }
+
+    if (configMatch) {
+      const baseId = decodeURIComponent(configMatch[1]);
+      if (method === "GET") {
+        const result = await this.getBaseConfig(baseId);
+        this.writeJson(res, result);
+        return;
+      }
+      if (method === "PUT") {
+        const payload = (body ? JSON.parse(body) : {}) as BaseConfigPayload;
+        const result = await this.upsertBaseConfig(baseId, payload);
+        this.writeJson(res, result);
+        return;
+      }
+    }
+
+    this.writeJson(res, { error: "Not Found" }, 404);
+  }
+
+  private writeJson(res: ServerResponse, payload: any, status = 200): void {
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(payload));
+  }
+
+  private sendMicroError(res: ServerResponse, error: unknown): void {
+    console.error("[Bases Bridge] Micro server error", error);
+    const status = error instanceof HttpError ? error.status : 500;
+    this.writeJson(res, { error: (error as Error)?.message ?? "Internal error" }, status);
+  }
+
+  private returnExpressError(res: any, error: unknown): void {
+    console.error("[Bases Bridge] REST error", error);
+    const status = error instanceof HttpError ? error.status : 500;
+    res.status(status).json({ error: (error as Error)?.message ?? "Internal error" });
+  }
+
+  // -----------------------------------------------------------------------
+  // Express helpers
+  // -----------------------------------------------------------------------
+
+  private async handleCreateBaseExpress(req: any, res: any): Promise<void> {
+    try {
+      const result = await this.createBaseFile(req.body as BaseCreatePayload);
+      res.status(result.ok && !req.body?.validateOnly ? 201 : 200).json(result);
+    } catch (error) {
+      this.returnExpressError(res, error);
+    }
+  }
+
+  private async handleGetSchemaExpress(req: any, res: any): Promise<void> {
+    try {
+      const baseId = decodeURIComponent(req.params.id);
+      const schema = await this.readBaseSchema(baseId);
+      res.json(schema);
+    } catch (error) {
+      this.returnExpressError(res, error);
+    }
+  }
+
+  private async handleQueryExpress(req: any, res: any): Promise<void> {
+    try {
+      const baseId = decodeURIComponent(req.params.id);
+      const payload = req.body as QueryPayload;
+      const result = await this.executeQuery(baseId, payload ?? {});
+      res.json(result);
+    } catch (error) {
+      this.returnExpressError(res, error);
+    }
+  }
+
+  private async handleUpsertExpress(req: any, res: any): Promise<void> {
+    try {
+      const baseId = decodeURIComponent(req.params.id);
+      const payload = req.body as UpsertPayload;
+      const result = await this.performUpsert(baseId, payload ?? { operations: [] });
+      res.json(result);
+    } catch (error) {
+      this.returnExpressError(res, error);
+    }
+  }
+
+  private async handleGetConfigExpress(req: any, res: any): Promise<void> {
+    try {
+      const baseId = decodeURIComponent(req.params.id);
+      const result = await this.getBaseConfig(baseId);
+      res.json(result);
+    } catch (error) {
+      this.returnExpressError(res, error);
+    }
+  }
+
+  private async handlePutConfigExpress(req: any, res: any): Promise<void> {
+    try {
+      const baseId = decodeURIComponent(req.params.id);
+      const payload = req.body as BaseConfigPayload;
+      const result = await this.upsertBaseConfig(baseId, payload ?? {});
+      res.json(result);
+    } catch (error) {
+      this.returnExpressError(res, error);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Core operations
+  // -----------------------------------------------------------------------
+
+  private async handleListBases(): Promise<Array<{ id: string; name: string; path: string }>> {
+    return this.app.vault
+      .getFiles()
+      .filter((file) => file.extension === "base")
+      .map((file) => ({ id: file.path, name: file.basename, path: file.path }))
+      .sort((a, b) => a.path.localeCompare(b.path));
+  }
+
+  private async readBaseSchema(baseId: string): Promise<Record<string, unknown>> {
+    const { file, config, yaml } = await this.loadBaseConfig(baseId);
+    const properties = Object.entries(config.properties ?? {}).map(([key, value]) => {
+      const record = (value ?? {}) as Record<string, unknown>;
+      const kind = inferPropertyKind(key, record);
+      return {
+        key,
+        kind,
+        displayName: typeof record.displayName === "string" ? record.displayName : undefined,
+        valueType: typeof record.valueType === "string" ? record.valueType : undefined,
+      };
+    });
+
+    const views = Array.isArray(config.views)
+      ? config.views.map((view: any) => ({
+          name: view?.name ?? "",
+          type: view?.type ?? "table",
+          limit: view?.limit,
+          order: Array.isArray(view?.order) ? view.order : [],
+          filters: view?.filters,
+          description: view?.description,
+        }))
+      : [];
+
+    return {
+      id: file.path,
+      path: file.path,
+      name: file.basename,
+      yaml,
+      properties,
+      formulas: config.formulas ?? {},
+      views,
+      filters: config.filters ?? {},
+    };
+  }
+
+  private async executeQuery(baseId: string, payload: QueryPayload): Promise<Record<string, unknown>> {
+    const evaluate = payload.evaluate ?? false;
+    const cacheEntry = evaluate ? this.engineCache.get(baseId) : undefined;
+
+    if (cacheEntry && cacheEntry.rows.length > 0) {
+      const filtered = applyFilter(cacheEntry.rows, payload.filter);
+      const sorted = applySort(filtered, payload.sort ?? cacheEntry.order);
+      const paginated = paginateRows(sorted, payload.limit ?? 50, payload.page ?? 1);
+      return {
+        total: filtered.length,
+        page: paginated.page,
+        rows: paginated.rows,
+        evaluate: true,
+        source: "engine",
+      };
+    }
+
+    // Fallback: read metadata and frontmatter
+    const rows = await this.evaluateFallback(baseId);
+    const filtered = applyFilter(rows, payload.filter);
+    const sorted = applySort(filtered, payload.sort ?? []);
+    const paginated = paginateRows(sorted, payload.limit ?? 50, payload.page ?? 1);
+    return {
+      total: filtered.length,
+      page: paginated.page,
+      rows: paginated.rows,
+      evaluate: false,
+      source: "fallback",
+    };
+  }
+
+  private async performUpsert(baseId: string, payload: UpsertPayload): Promise<Record<string, unknown>> {
+    if (!payload.operations || payload.operations.length === 0) {
+      throw new HttpError(400, "operations array required");
+    }
+
+    const results: Array<Record<string, unknown>> = [];
+    const errors: Array<Record<string, unknown>> = [];
+
+    for (const operation of payload.operations) {
+      try {
+        const result = await this.applyFrontmatterOperation(operation);
+        results.push(result);
+      } catch (error) {
+        if (payload.continueOnError) {
+          errors.push({
+            file: operation.file,
+            error: (error as Error).message,
+          });
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    return {
+      ok: errors.length === 0,
+      results,
+      errors,
+    };
+  }
+
+  private async createBaseFile(payload: BaseCreatePayload): Promise<Record<string, unknown>> {
+    if (!payload?.path || !payload?.spec) {
+      throw new HttpError(400, "path and spec are required");
+    }
+
+    const normalizedPath = normalizePath(payload.path);
+    const existing = this.app.vault.getAbstractFileByPath(normalizedPath);
+    if (existing && !payload.overwrite) {
+      throw new HttpError(409, `Base already exists: ${normalizedPath}`);
+    }
+
+    const yaml = stringifyYaml(payload.spec ?? {});
+
+    if (payload.validateOnly) {
+      // Parsing ensures validity
+      parseYaml(yaml);
+      return { ok: true, id: normalizedPath, warnings: [] };
+    }
+
+    const file = existing instanceof TFile ? existing : await this.app.vault.create(normalizedPath, yaml);
+    if (existing instanceof TFile && payload.overwrite) {
+      await this.app.vault.modify(file, yaml);
+    }
+
+    return { ok: true, id: file.path, warnings: [] };
+  }
+
+  private async getBaseConfig(baseId: string): Promise<Record<string, unknown>> {
+    const { file, config, yaml } = await this.loadBaseConfig(baseId);
+    return {
+      id: file.path,
+      yaml,
+      json: config,
+    };
+  }
+
+  private async upsertBaseConfig(baseId: string, payload: BaseConfigPayload): Promise<Record<string, unknown>> {
+    if (!payload.yaml && !payload.json) {
+      throw new HttpError(400, "yaml or json is required");
+    }
+
+    const file = this.requireBaseFile(baseId);
+    const yaml = payload.yaml ?? stringifyYaml(payload.json ?? {});
+
+    // Validate
+    const parsed = parseYaml(yaml) ?? {};
+
+    if (payload.validateOnly) {
+      return { ok: true, id: file.path, warnings: [] };
+    }
+
+    await this.app.vault.modify(file, yaml);
+    return { ok: true, id: file.path, warnings: [] };
+  }
+
+  private async loadBaseConfig(baseId: string): Promise<{ file: TFile; config: BaseDefinition; yaml: string }> {
+    const file = this.requireBaseFile(baseId);
+    const yaml = await this.app.vault.read(file);
+    const parsed = (parseYaml(yaml) ?? {}) as BaseDefinition;
+    return { file, config: parsed, yaml };
+  }
+
+  private requireBaseFile(baseId: string): TFile {
+    const normalizedPath = normalizePath(baseId);
+    const file = this.app.vault.getAbstractFileByPath(normalizedPath);
+    if (!(file instanceof TFile)) {
+      throw new HttpError(404, `Base not found: ${baseId}`);
+    }
+    return file;
+  }
+
+  private async evaluateFallback(baseId: string): Promise<BridgeRow[]> {
+    const definition = await this.loadBaseConfig(baseId);
+    const rows: BridgeRow[] = [];
+
+    for (const file of this.app.vault.getFiles()) {
+      if (file.extension !== "md") {
+        continue;
+      }
+      const cache = this.app.metadataCache.getFileCache(file);
+      const frontmatter = { ...(cache?.frontmatter ?? {}) } as Record<string, unknown>;
+      delete (frontmatter as any).position;
+
+      const props = normalizeFrontmatter(frontmatter);
+      const computed = {
+        "file.path": file.path,
+        "file.name": file.name,
+        "file.ext": file.extension,
+        "file.mtime": file.stat.mtime,
+        "file.ctime": file.stat.ctime,
+        "file.size": file.stat.size,
+      };
+
+      rows.push({
+        file: { path: file.path, name: file.name },
+        props,
+        computed,
+      });
+    }
+
+    return rows;
+  }
+
+  private async applyFrontmatterOperation(operation: UpsertOperation): Promise<Record<string, unknown>> {
+    if (!operation.file) {
+      throw new HttpError(400, "operation.file is required");
+    }
+
+    const normalizedPath = normalizePath(operation.file);
+    const file = this.app.vault.getAbstractFileByPath(normalizedPath);
+    if (!(file instanceof TFile)) {
+      throw new HttpError(404, `File not found: ${operation.file}`);
+    }
+
+    if (operation.expected_mtime && file.stat.mtime !== operation.expected_mtime) {
+      throw new HttpError(409, `mtime mismatch for ${operation.file}`);
+    }
+
+    await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+      if (operation.unset) {
+        for (const key of operation.unset) {
+          if (isReservedProperty(key)) {
+            throw new HttpError(400, `Cannot unset protected key ${key}`);
+          }
+          delete frontmatter[key];
+        }
+      }
+
+      if (operation.set) {
+        for (const [key, rawValue] of Object.entries(operation.set)) {
+          if (isReservedProperty(key)) {
+            throw new HttpError(400, `Cannot set protected key ${key}`);
+          }
+          frontmatter[key] = normalizeFrontmatterValue(rawValue);
+        }
+      }
+    });
+
+    const stat = await this.app.vault.adapter.stat(file.path);
+    return {
+      file: file.path,
+      mtime: stat?.mtime ?? file.stat.mtime,
+      changed: {
+        keys: Object.keys(operation.set ?? {}),
+        unset: operation.unset ?? [],
+      },
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper utilities
+// ---------------------------------------------------------------------------
+
+class HttpError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", (chunk) => {
+      data += chunk;
+    });
+    req.on("end", () => resolve(data));
+    req.on("error", (error) => reject(error));
+  });
+}
+
+function normalizeEngineValue(value: unknown): unknown {
+  if (!value) return value;
+  if (typeof value === "object" && value !== null) {
+    if (typeof (value as any).toString === "function") {
+      return (value as any).toString();
+    }
+  }
+  return value;
+}
+
+function normalizeFrontmatter(frontmatter: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(frontmatter)) {
+    result[key] = normalizeFrontmatterValue(value);
+  }
+  return result;
+}
+
+function normalizeFrontmatterValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    if (/^#/.test(value)) {
+      return [value.replace(/^#/, "")];
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      typeof item === "string" && item.startsWith("#") ? item.replace(/^#/, "") : item,
+    );
+  }
+  return value;
+}
+
+function isReservedProperty(key: string): boolean {
+  return key.startsWith("formula.") || key.startsWith("file.");
+}
+
+function inferPropertyKind(key: string, value: Record<string, unknown>): string {
+  if (key.startsWith("formula.")) return "formula";
+  if (key.startsWith("file.")) return "file";
+  if (typeof value.kind === "string") return value.kind;
+  return "note";
+}
+
+function applyFilter(rows: BridgeRow[], filter?: AdditionalFilter): BridgeRow[] {
+  if (!filter) return rows;
+  return rows.filter((row) => matchFilter(row, filter));
+}
+
+function matchFilter(row: BridgeRow, filter: AdditionalFilter): boolean {
+  if (filter.eq) {
+    for (const [key, expected] of Object.entries(filter.eq)) {
+      const value = readRowValue(row, key);
+      if (value !== expected) return false;
+    }
+  }
+  if (filter.in) {
+    for (const [key, list] of Object.entries(filter.in)) {
+      const value = readRowValue(row, key);
+      if (!Array.isArray(list) || !list.includes(value as any)) return false;
+    }
+  }
+  if (filter.regex) {
+    for (const [key, pattern] of Object.entries(filter.regex)) {
+      const value = readRowValue(row, key);
+      if (typeof value !== "string" || !new RegExp(pattern).test(value)) {
+        return false;
+      }
+    }
+  }
+  if (filter.and) {
+    if (!filter.and.every((sub) => matchFilter(row, sub))) return false;
+  }
+  if (filter.or) {
+    if (!filter.or.some((sub) => matchFilter(row, sub))) return false;
+  }
+  if (filter.not) {
+    if (matchFilter(row, filter.not)) return false;
+  }
+  return true;
+}
+
+function readRowValue(row: BridgeRow, key: string): unknown {
+  if (key.startsWith("file.")) {
+    return row.computed[key];
+  }
+  if (key in row.props) {
+    return row.props[key];
+  }
+  return undefined;
+}
+
+function applySort(rows: BridgeRow[], sort: Array<{ prop: string; dir?: SortDirection }> | string[]): BridgeRow[] {
+  if (!sort || sort.length === 0) return rows;
+  const sortArray = Array.isArray(sort)
+    ? sort.map((item) => (typeof item === "string" ? { prop: item, dir: "asc" as SortDirection } : item))
+    : [];
+
+  const cloned = [...rows];
+  cloned.sort((a, b) => {
+    for (const descriptor of sortArray) {
+      const dir = descriptor.dir ?? "asc";
+      const left = readRowValue(a, descriptor.prop);
+      const right = readRowValue(b, descriptor.prop);
+      if (left === right) continue;
+      if (left == null) return dir === "asc" ? -1 : 1;
+      if (right == null) return dir === "asc" ? 1 : -1;
+      if (left < right) return dir === "asc" ? -1 : 1;
+      if (left > right) return dir === "asc" ? 1 : -1;
+    }
+    return 0;
+  });
+  return cloned;
+}
+
+function paginateRows(rows: BridgeRow[], limit: number, page: number): { rows: BridgeRow[]; page: number } {
+  const safeLimit = Math.min(Math.max(limit, 1), 500);
+  const safePage = Math.max(page, 1);
+  const offset = (safePage - 1) * safeLimit;
+  return {
+    rows: rows.slice(offset, offset + safeLimit),
+    page: safePage,
+  };
+}

--- a/plugins/obsidian-bases-bridge/tsconfig.json
+++ b/plugins/obsidian-bases-bridge/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": false,
+    "skipLibCheck": true,
+    "baseUrl": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/src/mcp-server/server.ts
+++ b/src/mcp-server/server.ts
@@ -34,6 +34,12 @@ import { registerObsidianUpdateNoteTool } from "./tools/obsidianUpdateNoteTool/i
 import { registerObsidianManageFrontmatterTool } from "./tools/obsidianManageFrontmatterTool/index.js";
 import { registerObsidianManageTagsTool } from "./tools/obsidianManageTagsTool/index.js";
 import { registerSemanticSearchTool } from "./tools/semanticSearchTool/index.js";
+import { registerBasesListTool } from "./tools/basesListTool/index.js";
+import { registerBasesGetSchemaTool } from "./tools/basesGetSchemaTool/index.js";
+import { registerBasesQueryTool } from "./tools/basesQueryTool/index.js";
+import { registerBasesUpsertRowsTool } from "./tools/basesUpsertRowsTool/index.js";
+import { registerBasesCreateTool } from "./tools/basesCreateTool/index.js";
+import { registerBasesUpsertConfigTool } from "./tools/basesUpsertConfigTool/index.js";
 // Import transport setup functions.
 import { startHttpTransport } from "./transports/httpTransport.js";
 import { connectStdioTransport } from "./transports/stdioTransport.js";
@@ -147,6 +153,12 @@ async function createMcpServerInstance(
       obsidianService,
       vaultCacheService,
     );
+    await registerBasesListTool(server, obsidianService);
+    await registerBasesGetSchemaTool(server, obsidianService);
+    await registerBasesQueryTool(server, obsidianService);
+    await registerBasesUpsertRowsTool(server, obsidianService);
+    await registerBasesCreateTool(server, obsidianService);
+    await registerBasesUpsertConfigTool(server, obsidianService);
 
     logger.info("Resources and tools registered successfully", context);
 

--- a/src/mcp-server/tools/basesCreateTool/index.ts
+++ b/src/mcp-server/tools/basesCreateTool/index.ts
@@ -1,0 +1,1 @@
+export { registerBasesCreateTool } from "./registration.js";

--- a/src/mcp-server/tools/basesCreateTool/logic.ts
+++ b/src/mcp-server/tools/basesCreateTool/logic.ts
@@ -1,0 +1,67 @@
+/**
+ * @fileoverview Logic for the `bases_create` MCP tool.
+ */
+
+import { z } from "zod";
+import { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
+import {
+  BaseCreateRequest,
+  BaseCreateResponse,
+} from "../../../services/obsidianRestAPI/types.js";
+import {
+  logger,
+  RequestContext,
+  requestContextService,
+} from "../../../utils/index.js";
+
+export const BasesCreateInputSchema = z
+  .object({
+    path: z
+      .string()
+      .min(1)
+      .describe("Chemin cible du nouveau fichier .base (relatif au coffre)."),
+    spec: z
+      .record(z.any())
+      .describe(
+        "Spécification JSON conforme à la syntaxe Bases (filters, properties, formulas, views).",
+      ),
+    overwrite: z
+      .boolean()
+      .default(false)
+      .describe("Autoriser l'écrasement si le fichier existe déjà."),
+    validateOnly: z
+      .boolean()
+      .default(false)
+      .describe("Quand true, valide uniquement la spec sans écrire sur disque."),
+  })
+  .describe(
+    "Crée un nouveau fichier .base (ou valide la spec) via le bridge REST obsidian-bases-bridge.",
+  );
+
+export type BasesCreateInput = z.infer<typeof BasesCreateInputSchema>;
+
+export async function processBasesCreate(
+  params: BasesCreateInput,
+  parentContext: RequestContext,
+  obsidianService: ObsidianRestApiService,
+): Promise<BaseCreateResponse> {
+  const payload: BaseCreateRequest = {
+    path: params.path,
+    spec: params.spec,
+    overwrite: params.overwrite,
+    validateOnly: params.validateOnly,
+  };
+
+  const context = requestContextService.createRequestContext({
+    parentContext,
+    operation: "BasesCreate",
+    params: {
+      path: params.path,
+      overwrite: params.overwrite,
+      validateOnly: params.validateOnly,
+    },
+  });
+
+  logger.debug("Creating base via REST bridge", context);
+  return obsidianService.createBase(payload, context);
+}

--- a/src/mcp-server/tools/basesCreateTool/registration.ts
+++ b/src/mcp-server/tools/basesCreateTool/registration.ts
@@ -1,0 +1,86 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
+import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
+import {
+  ErrorHandler,
+  logger,
+  RequestContext,
+  requestContextService,
+} from "../../../utils/index.js";
+import {
+  BasesCreateInput,
+  BasesCreateInputSchema,
+  processBasesCreate,
+} from "./logic.js";
+
+const TOOL_NAME = "bases_create";
+const TOOL_DESCRIPTION =
+  "Crée (ou valide) une nouvelle base .base en générant le YAML via le bridge REST.";
+
+export async function registerBasesCreateTool(
+  server: McpServer,
+  obsidianService: ObsidianRestApiService,
+): Promise<void> {
+  const registrationContext: RequestContext =
+    requestContextService.createRequestContext({
+      operation: "RegisterBasesCreateTool",
+      toolName: TOOL_NAME,
+    });
+
+  await ErrorHandler.tryCatch(
+    async () => {
+      server.tool(
+        TOOL_NAME,
+        TOOL_DESCRIPTION,
+        BasesCreateInputSchema.shape,
+        async (params: BasesCreateInput) => {
+          const handlerContext = requestContextService.createRequestContext({
+            parentContext: registrationContext,
+            operation: "HandleBasesCreate",
+            toolName: TOOL_NAME,
+            params: {
+              path: params.path,
+              overwrite: params.overwrite,
+              validateOnly: params.validateOnly,
+            },
+          });
+
+          const result = await processBasesCreate(
+            params,
+            handlerContext,
+            obsidianService,
+          );
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(result, null, 2),
+              },
+            ],
+            isError: false,
+          };
+        },
+      );
+
+      logger.info(
+        `Tool ${TOOL_NAME} enregistré avec succès`,
+        registrationContext,
+      );
+    },
+    {
+      operation: "registerBasesCreateTool",
+      context: registrationContext,
+      errorCode: BaseErrorCode.INTERNAL_ERROR,
+      errorMapper: (error: unknown) =>
+        new McpError(
+          error instanceof McpError ? error.code : BaseErrorCode.INTERNAL_ERROR,
+          `Impossible d'enregistrer ${TOOL_NAME}: ${
+            error instanceof Error ? error.message : "Erreur inconnue"
+          }`,
+          registrationContext,
+        ),
+      critical: true,
+    },
+  );
+}

--- a/src/mcp-server/tools/basesGetSchemaTool/index.ts
+++ b/src/mcp-server/tools/basesGetSchemaTool/index.ts
@@ -1,0 +1,1 @@
+export { registerBasesGetSchemaTool } from "./registration.js";

--- a/src/mcp-server/tools/basesGetSchemaTool/logic.ts
+++ b/src/mcp-server/tools/basesGetSchemaTool/logic.ts
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview Logic for the `bases_get_schema` MCP tool.
+ */
+
+import { z } from "zod";
+import { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
+import { BaseSchemaResponse } from "../../../services/obsidianRestAPI/types.js";
+import {
+  logger,
+  RequestContext,
+  requestContextService,
+} from "../../../utils/index.js";
+
+export const BasesGetSchemaInputSchema = z
+  .object({
+    base_id: z
+      .string()
+      .min(1)
+      .describe("Identifiant (chemin) de la base, par ex. 'Content/plan.base'."),
+  })
+  .describe(
+    "Récupère le schéma (propriétés, vues, formules) d'une base déclarée dans un fichier .base.",
+  );
+
+export type BasesGetSchemaInput = z.infer<typeof BasesGetSchemaInputSchema>;
+
+export async function processBasesGetSchema(
+  params: BasesGetSchemaInput,
+  parentContext: RequestContext,
+  obsidianService: ObsidianRestApiService,
+): Promise<BaseSchemaResponse> {
+  const context = requestContextService.createRequestContext({
+    parentContext,
+    operation: "BasesGetSchema",
+    params,
+  });
+  logger.debug("Fetching Base schema via REST bridge", context);
+  return obsidianService.getBaseSchema(params.base_id, context);
+}

--- a/src/mcp-server/tools/basesGetSchemaTool/registration.ts
+++ b/src/mcp-server/tools/basesGetSchemaTool/registration.ts
@@ -1,0 +1,82 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
+import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
+import {
+  ErrorHandler,
+  logger,
+  RequestContext,
+  requestContextService,
+} from "../../../utils/index.js";
+import {
+  BasesGetSchemaInput,
+  BasesGetSchemaInputSchema,
+  processBasesGetSchema,
+} from "./logic.js";
+
+const TOOL_NAME = "bases_get_schema";
+const TOOL_DESCRIPTION =
+  "Retourne le schéma (propriétés, vues, formules) d'une base .base via le bridge REST.";
+
+export async function registerBasesGetSchemaTool(
+  server: McpServer,
+  obsidianService: ObsidianRestApiService,
+): Promise<void> {
+  const registrationContext: RequestContext =
+    requestContextService.createRequestContext({
+      operation: "RegisterBasesGetSchemaTool",
+      toolName: TOOL_NAME,
+    });
+
+  await ErrorHandler.tryCatch(
+    async () => {
+      server.tool(
+        TOOL_NAME,
+        TOOL_DESCRIPTION,
+        BasesGetSchemaInputSchema.shape,
+        async (params: BasesGetSchemaInput) => {
+          const handlerContext = requestContextService.createRequestContext({
+            parentContext: registrationContext,
+            operation: "HandleBasesGetSchema",
+            toolName: TOOL_NAME,
+            params,
+          });
+
+          const result = await processBasesGetSchema(
+            params,
+            handlerContext,
+            obsidianService,
+          );
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(result, null, 2),
+              },
+            ],
+            isError: false,
+          };
+        },
+      );
+
+      logger.info(
+        `Tool ${TOOL_NAME} enregistré avec succès`,
+        registrationContext,
+      );
+    },
+    {
+      operation: "registerBasesGetSchemaTool",
+      context: registrationContext,
+      errorCode: BaseErrorCode.INTERNAL_ERROR,
+      errorMapper: (error: unknown) =>
+        new McpError(
+          error instanceof McpError ? error.code : BaseErrorCode.INTERNAL_ERROR,
+          `Impossible d'enregistrer ${TOOL_NAME}: ${
+            error instanceof Error ? error.message : "Erreur inconnue"
+          }`,
+          registrationContext,
+        ),
+      critical: true,
+    },
+  );
+}

--- a/src/mcp-server/tools/basesListTool/index.ts
+++ b/src/mcp-server/tools/basesListTool/index.ts
@@ -1,0 +1,1 @@
+export { registerBasesListTool } from "./registration.js";

--- a/src/mcp-server/tools/basesListTool/logic.ts
+++ b/src/mcp-server/tools/basesListTool/logic.ts
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Logic for the `bases_list` MCP tool.
+ *
+ * This tool surfaces the list of Bases (`*.base` YAML files) discovered by the
+ * obsidian-bases-bridge plugin. It simply proxies the response from the bridge
+ * to the MCP client.
+ */
+
+import { z } from "zod";
+import { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
+import {
+  BasesListResponse as BasesListResult,
+} from "../../../services/obsidianRestAPI/types.js";
+import {
+  logger,
+  RequestContext,
+  requestContextService,
+} from "../../../utils/index.js";
+
+/**
+ * Input schema (empty object) required by the MCP SDK registration.
+ */
+export const BasesListInputSchema = z
+  .object({})
+  .strict()
+  .describe(
+    "Liste les fichiers .base disponibles dans le coffre Obsidian. Ne prend aucun paramètre.",
+  );
+
+export type BasesListInput = z.infer<typeof BasesListInputSchema>;
+
+/**
+ * Core logic that calls the Obsidian REST API bridge.
+ */
+export async function processBasesList(
+  _params: BasesListInput,
+  parentContext: RequestContext,
+  obsidianService: ObsidianRestApiService,
+): Promise<BasesListResult> {
+  const context = requestContextService.createRequestContext({
+    parentContext,
+    operation: "BasesList",
+  });
+  logger.debug("Fetching Bases list via REST bridge", context);
+  return obsidianService.listBases(context);
+}

--- a/src/mcp-server/tools/basesListTool/registration.ts
+++ b/src/mcp-server/tools/basesListTool/registration.ts
@@ -1,0 +1,87 @@
+/**
+ * @fileoverview Registers the `bases_list` MCP tool.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
+import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
+import {
+  ErrorHandler,
+  logger,
+  RequestContext,
+  requestContextService,
+} from "../../../utils/index.js";
+import {
+  BasesListInput,
+  BasesListInputSchema,
+  processBasesList,
+} from "./logic.js";
+
+const TOOL_NAME = "bases_list";
+const TOOL_DESCRIPTION =
+  "Liste les Bases (.base) disponibles via le bridge REST."
+  + " Utilise l'extension obsidian-bases-bridge du plugin Local REST API.";
+
+export async function registerBasesListTool(
+  server: McpServer,
+  obsidianService: ObsidianRestApiService,
+): Promise<void> {
+  const registrationContext: RequestContext =
+    requestContextService.createRequestContext({
+      operation: "RegisterBasesListTool",
+      toolName: TOOL_NAME,
+    });
+
+  await ErrorHandler.tryCatch(
+    async () => {
+      logger.info(`Enregistrement du tool ${TOOL_NAME}`, registrationContext);
+      server.tool(
+        TOOL_NAME,
+        TOOL_DESCRIPTION,
+        BasesListInputSchema.shape,
+        async (_params: BasesListInput) => {
+          const handlerContext = requestContextService.createRequestContext({
+            parentContext: registrationContext,
+            operation: "HandleBasesList",
+            toolName: TOOL_NAME,
+          });
+
+          const result = await processBasesList(
+            {},
+            handlerContext,
+            obsidianService,
+          );
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(result, null, 2),
+              },
+            ],
+            isError: false,
+          };
+        },
+      );
+
+      logger.info(
+        `Tool ${TOOL_NAME} enregistré avec succès`,
+        registrationContext,
+      );
+    },
+    {
+      operation: "registerBasesListTool",
+      context: registrationContext,
+      errorCode: BaseErrorCode.INTERNAL_ERROR,
+      errorMapper: (error: unknown) =>
+        new McpError(
+          error instanceof McpError ? error.code : BaseErrorCode.INTERNAL_ERROR,
+          `Échec de l'enregistrement du tool ${TOOL_NAME}: ${
+            error instanceof Error ? error.message : "Erreur inconnue"
+          }`,
+          registrationContext,
+        ),
+      critical: true,
+    },
+  );
+}

--- a/src/mcp-server/tools/basesQueryTool/index.ts
+++ b/src/mcp-server/tools/basesQueryTool/index.ts
@@ -1,0 +1,1 @@
+export { registerBasesQueryTool } from "./registration.js";

--- a/src/mcp-server/tools/basesQueryTool/logic.ts
+++ b/src/mcp-server/tools/basesQueryTool/logic.ts
@@ -1,0 +1,94 @@
+/**
+ * @fileoverview Logic for the `bases_query` MCP tool.
+ */
+
+import { z } from "zod";
+import { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
+import {
+  BaseQueryRequest,
+  BaseQueryResponse,
+} from "../../../services/obsidianRestAPI/types.js";
+import {
+  logger,
+  RequestContext,
+  requestContextService,
+} from "../../../utils/index.js";
+
+const SortSchema = z
+  .object({
+    prop: z
+      .string()
+      .min(1)
+      .describe("Identifiant de propriété (ex. 'priority' ou 'file.mtime')."),
+    dir: z.enum(["asc", "desc"]).default("asc"),
+  })
+  .describe("Critère de tri supplémentaire.");
+
+export const BasesQueryInputSchema = z
+  .object({
+    base_id: z
+      .string()
+      .min(1)
+      .describe("Identifiant (chemin) du fichier .base à interroger."),
+    view: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Vue à utiliser pour l'ordre/les formules. Optionnel."),
+    filter: z
+      .record(z.any())
+      .optional()
+      .describe("Filtre additionnel (JSON) appliqué par le bridge."),
+    sort: z
+      .array(SortSchema)
+      .optional()
+      .describe("Critères de tri supplémentaires (en plus de la vue)."),
+    limit: z
+      .number()
+      .min(1)
+      .max(500)
+      .default(50)
+      .describe("Nombre max de lignes par page (<= 500)."),
+    page: z
+      .number()
+      .min(1)
+      .default(1)
+      .describe("Numéro de page (1-indexé)."),
+    evaluate: z
+      .boolean()
+      .default(true)
+      .describe("Quand true, force l'utilisation des valeurs évaluées si disponibles."),
+  })
+  .describe(
+    "Exécute une requête sur une base. Supporte filtres additionnels, tri, pagination et mode evaluate (engine).",
+  );
+
+export type BasesQueryInput = z.infer<typeof BasesQueryInputSchema>;
+
+export async function processBasesQuery(
+  params: BasesQueryInput,
+  parentContext: RequestContext,
+  obsidianService: ObsidianRestApiService,
+): Promise<BaseQueryResponse> {
+  const payload: BaseQueryRequest = {
+    view: params.view,
+    filter: params.filter,
+    sort: params.sort,
+    limit: params.limit,
+    page: params.page,
+    evaluate: params.evaluate,
+  };
+
+  const context = requestContextService.createRequestContext({
+    parentContext,
+    operation: "BasesQuery",
+    params: {
+      ...params,
+      filter: params.filter ? "<payload>" : undefined,
+      sort: params.sort ? params.sort.length : undefined,
+    },
+  });
+
+  logger.debug("Querying base via REST bridge", context);
+  return obsidianService.queryBase(params.base_id, payload, context);
+}

--- a/src/mcp-server/tools/basesQueryTool/registration.ts
+++ b/src/mcp-server/tools/basesQueryTool/registration.ts
@@ -1,0 +1,82 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
+import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
+import {
+  ErrorHandler,
+  logger,
+  RequestContext,
+  requestContextService,
+} from "../../../utils/index.js";
+import {
+  BasesQueryInput,
+  BasesQueryInputSchema,
+  processBasesQuery,
+} from "./logic.js";
+
+const TOOL_NAME = "bases_query";
+const TOOL_DESCRIPTION =
+  "Exécute une requête sur une base (.base) avec filtres additionnels, tri et pagination.";
+
+export async function registerBasesQueryTool(
+  server: McpServer,
+  obsidianService: ObsidianRestApiService,
+): Promise<void> {
+  const registrationContext: RequestContext =
+    requestContextService.createRequestContext({
+      operation: "RegisterBasesQueryTool",
+      toolName: TOOL_NAME,
+    });
+
+  await ErrorHandler.tryCatch(
+    async () => {
+      server.tool(
+        TOOL_NAME,
+        TOOL_DESCRIPTION,
+        BasesQueryInputSchema.shape,
+        async (params: BasesQueryInput) => {
+          const handlerContext = requestContextService.createRequestContext({
+            parentContext: registrationContext,
+            operation: "HandleBasesQuery",
+            toolName: TOOL_NAME,
+            params,
+          });
+
+          const result = await processBasesQuery(
+            params,
+            handlerContext,
+            obsidianService,
+          );
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(result, null, 2),
+              },
+            ],
+            isError: false,
+          };
+        },
+      );
+
+      logger.info(
+        `Tool ${TOOL_NAME} enregistré avec succès`,
+        registrationContext,
+      );
+    },
+    {
+      operation: "registerBasesQueryTool",
+      context: registrationContext,
+      errorCode: BaseErrorCode.INTERNAL_ERROR,
+      errorMapper: (error: unknown) =>
+        new McpError(
+          error instanceof McpError ? error.code : BaseErrorCode.INTERNAL_ERROR,
+          `Impossible d'enregistrer ${TOOL_NAME}: ${
+            error instanceof Error ? error.message : "Erreur inconnue"
+          }`,
+          registrationContext,
+        ),
+      critical: true,
+    },
+  );
+}

--- a/src/mcp-server/tools/basesUpsertConfigTool/index.ts
+++ b/src/mcp-server/tools/basesUpsertConfigTool/index.ts
@@ -1,0 +1,1 @@
+export { registerBasesUpsertConfigTool } from "./registration.js";

--- a/src/mcp-server/tools/basesUpsertConfigTool/logic.ts
+++ b/src/mcp-server/tools/basesUpsertConfigTool/logic.ts
@@ -1,0 +1,78 @@
+/**
+ * @fileoverview Logic for the `bases_upsert_config` MCP tool.
+ */
+
+import { z } from "zod";
+import { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
+import {
+  BaseConfigUpsertRequest,
+  BaseConfigUpsertResponse,
+} from "../../../services/obsidianRestAPI/types.js";
+import {
+  logger,
+  RequestContext,
+  requestContextService,
+} from "../../../utils/index.js";
+import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
+
+const RawBasesUpsertConfigInputSchema = z
+  .object({
+    base_id: z
+      .string()
+      .min(1)
+      .describe("Identifiant (chemin) du fichier .base à mettre à jour."),
+    yaml: z
+      .string()
+      .optional()
+      .describe("YAML complet de la base. Optionnel si 'json' est fourni."),
+    json: z
+      .record(z.any())
+      .optional()
+      .describe("Spécification JSON de la base. Optionnel si 'yaml' est fourni."),
+    validateOnly: z
+      .boolean()
+      .default(false)
+      .describe("Quand true, valide la configuration sans écrire."),
+  })
+  .describe(
+    "Remplace ou valide la configuration d'un fichier .base (YAML ou JSON) via le bridge REST.",
+  );
+
+export const BasesUpsertConfigInputSchema = RawBasesUpsertConfigInputSchema;
+
+export type BasesUpsertConfigInput = z.infer<
+  typeof BasesUpsertConfigInputSchema
+>;
+
+export async function processBasesUpsertConfig(
+  params: BasesUpsertConfigInput,
+  parentContext: RequestContext,
+  obsidianService: ObsidianRestApiService,
+): Promise<BaseConfigUpsertResponse> {
+  if (!params.yaml && !params.json) {
+    throw new McpError(
+      BaseErrorCode.VALIDATION_ERROR,
+      "Fournir au moins 'yaml' ou 'json' pour mettre à jour la base.",
+    );
+  }
+
+  const payload: BaseConfigUpsertRequest = {
+    yaml: params.yaml,
+    json: params.json,
+    validateOnly: params.validateOnly,
+  };
+
+  const context = requestContextService.createRequestContext({
+    parentContext,
+    operation: "BasesUpsertConfig",
+    params: {
+      base_id: params.base_id,
+      hasYaml: Boolean(params.yaml),
+      hasJson: Boolean(params.json),
+      validateOnly: params.validateOnly,
+    },
+  });
+
+  logger.debug("Updating base config via REST bridge", context);
+  return obsidianService.upsertBaseConfig(params.base_id, payload, context);
+}

--- a/src/mcp-server/tools/basesUpsertConfigTool/registration.ts
+++ b/src/mcp-server/tools/basesUpsertConfigTool/registration.ts
@@ -1,0 +1,87 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
+import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
+import {
+  ErrorHandler,
+  logger,
+  RequestContext,
+  requestContextService,
+} from "../../../utils/index.js";
+import {
+  BasesUpsertConfigInput,
+  BasesUpsertConfigInputSchema,
+  processBasesUpsertConfig,
+} from "./logic.js";
+
+const TOOL_NAME = "bases_upsert_config";
+const TOOL_DESCRIPTION =
+  "Met à jour (ou valide) la configuration YAML/JSON d'une base via le bridge REST.";
+
+export async function registerBasesUpsertConfigTool(
+  server: McpServer,
+  obsidianService: ObsidianRestApiService,
+): Promise<void> {
+  const registrationContext: RequestContext =
+    requestContextService.createRequestContext({
+      operation: "RegisterBasesUpsertConfigTool",
+      toolName: TOOL_NAME,
+    });
+
+  await ErrorHandler.tryCatch(
+    async () => {
+      server.tool(
+        TOOL_NAME,
+        TOOL_DESCRIPTION,
+        BasesUpsertConfigInputSchema.shape,
+        async (params: BasesUpsertConfigInput) => {
+          const handlerContext = requestContextService.createRequestContext({
+            parentContext: registrationContext,
+            operation: "HandleBasesUpsertConfig",
+            toolName: TOOL_NAME,
+            params: {
+              base_id: params.base_id,
+              hasYaml: Boolean(params.yaml),
+              hasJson: Boolean(params.json),
+              validateOnly: params.validateOnly,
+            },
+          });
+
+          const result = await processBasesUpsertConfig(
+            params,
+            handlerContext,
+            obsidianService,
+          );
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(result, null, 2),
+              },
+            ],
+            isError: false,
+          };
+        },
+      );
+
+      logger.info(
+        `Tool ${TOOL_NAME} enregistré avec succès`,
+        registrationContext,
+      );
+    },
+    {
+      operation: "registerBasesUpsertConfigTool",
+      context: registrationContext,
+      errorCode: BaseErrorCode.INTERNAL_ERROR,
+      errorMapper: (error: unknown) =>
+        new McpError(
+          error instanceof McpError ? error.code : BaseErrorCode.INTERNAL_ERROR,
+          `Impossible d'enregistrer ${TOOL_NAME}: ${
+            error instanceof Error ? error.message : "Erreur inconnue"
+          }`,
+          registrationContext,
+        ),
+      critical: true,
+    },
+  );
+}

--- a/src/mcp-server/tools/basesUpsertRowsTool/index.ts
+++ b/src/mcp-server/tools/basesUpsertRowsTool/index.ts
@@ -1,0 +1,1 @@
+export { registerBasesUpsertRowsTool } from "./registration.js";

--- a/src/mcp-server/tools/basesUpsertRowsTool/logic.ts
+++ b/src/mcp-server/tools/basesUpsertRowsTool/logic.ts
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview Logic for the `bases_upsert_rows` MCP tool.
+ */
+
+import { z } from "zod";
+import { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
+import {
+  BaseUpsertRequest,
+  BaseUpsertResponse,
+} from "../../../services/obsidianRestAPI/types.js";
+import {
+  logger,
+  RequestContext,
+  requestContextService,
+} from "../../../utils/index.js";
+
+const OperationSchema = z
+  .object({
+    file: z
+      .string()
+      .min(1)
+      .describe(
+        "Chemin de la note ciblée (relatif au coffre), ex. 'SEO/Pages/13-Aix.md'.",
+      ),
+    set: z
+      .record(z.any())
+      .optional()
+      .describe("Valeurs de frontmatter à appliquer."),
+    unset: z
+      .array(z.string().min(1))
+      .optional()
+      .describe("Clés de frontmatter à supprimer."),
+    expected_mtime: z
+      .number()
+      .optional()
+      .describe(
+        "Timestamp mtime attendu (verrou optimiste). Conflit => 409 renvoyé par le bridge.",
+      ),
+  })
+  .describe("Opération d'upsert frontmatter pour une note.");
+
+export const BasesUpsertRowsInputSchema = z
+  .object({
+    base_id: z
+      .string()
+      .min(1)
+      .describe("Identifiant (chemin) de la base utilisée pour contextualiser la mise à jour."),
+    operations: z
+      .array(OperationSchema)
+      .min(1)
+      .describe("Tableau d'opérations d'upsert frontmatter."),
+    continueOnError: z
+      .boolean()
+      .default(false)
+      .describe("Quand true, poursuit les opérations malgré les erreurs individuelles."),
+  })
+  .describe(
+    "Met à jour en lot les propriétés de notes référencées par une base (.base). Respecte le verrou mtime et interdit les clés formula.* / file.* côté bridge.",
+  );
+
+export type BasesUpsertRowsInput = z.infer<typeof BasesUpsertRowsInputSchema>;
+
+export async function processBasesUpsertRows(
+  params: BasesUpsertRowsInput,
+  parentContext: RequestContext,
+  obsidianService: ObsidianRestApiService,
+): Promise<BaseUpsertResponse> {
+  const payload: BaseUpsertRequest = {
+    operations: params.operations.map((operation) => ({
+      file: operation.file,
+      set: operation.set,
+      unset: operation.unset,
+      expected_mtime: operation.expected_mtime,
+    })),
+    continueOnError: params.continueOnError,
+  };
+
+  const context = requestContextService.createRequestContext({
+    parentContext,
+    operation: "BasesUpsertRows",
+    params: {
+      base_id: params.base_id,
+      operations: params.operations.length,
+      continueOnError: params.continueOnError,
+    },
+  });
+
+  logger.debug("Upserting rows via REST bridge", context);
+  return obsidianService.upsertBaseRows(params.base_id, payload, context);
+}

--- a/src/mcp-server/tools/basesUpsertRowsTool/registration.ts
+++ b/src/mcp-server/tools/basesUpsertRowsTool/registration.ts
@@ -1,0 +1,86 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
+import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
+import {
+  ErrorHandler,
+  logger,
+  RequestContext,
+  requestContextService,
+} from "../../../utils/index.js";
+import {
+  BasesUpsertRowsInput,
+  BasesUpsertRowsInputSchema,
+  processBasesUpsertRows,
+} from "./logic.js";
+
+const TOOL_NAME = "bases_upsert_rows";
+const TOOL_DESCRIPTION =
+  "Met à jour les propriétés de notes issues d'une base via le bridge REST (set/unset + mtime).";
+
+export async function registerBasesUpsertRowsTool(
+  server: McpServer,
+  obsidianService: ObsidianRestApiService,
+): Promise<void> {
+  const registrationContext: RequestContext =
+    requestContextService.createRequestContext({
+      operation: "RegisterBasesUpsertRowsTool",
+      toolName: TOOL_NAME,
+    });
+
+  await ErrorHandler.tryCatch(
+    async () => {
+      server.tool(
+        TOOL_NAME,
+        TOOL_DESCRIPTION,
+        BasesUpsertRowsInputSchema.shape,
+        async (params: BasesUpsertRowsInput) => {
+          const handlerContext = requestContextService.createRequestContext({
+            parentContext: registrationContext,
+            operation: "HandleBasesUpsertRows",
+            toolName: TOOL_NAME,
+            params: {
+              base_id: params.base_id,
+              operations: params.operations.length,
+              continueOnError: params.continueOnError,
+            },
+          });
+
+          const result = await processBasesUpsertRows(
+            params,
+            handlerContext,
+            obsidianService,
+          );
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(result, null, 2),
+              },
+            ],
+            isError: false,
+          };
+        },
+      );
+
+      logger.info(
+        `Tool ${TOOL_NAME} enregistré avec succès`,
+        registrationContext,
+      );
+    },
+    {
+      operation: "registerBasesUpsertRowsTool",
+      context: registrationContext,
+      errorCode: BaseErrorCode.INTERNAL_ERROR,
+      errorMapper: (error: unknown) =>
+        new McpError(
+          error instanceof McpError ? error.code : BaseErrorCode.INTERNAL_ERROR,
+          `Impossible d'enregistrer ${TOOL_NAME}: ${
+            error instanceof Error ? error.message : "Erreur inconnue"
+          }`,
+          registrationContext,
+        ),
+      critical: true,
+    },
+  );
+}

--- a/src/services/obsidianRestAPI/index.ts
+++ b/src/services/obsidianRestAPI/index.ts
@@ -9,6 +9,7 @@ export * from "./types.js"; // Export all types
 export { ObsidianRestApiService } from "./service.js"; // Export the class itself
 // Export method modules if direct access is desired, though typically accessed via service instance
 export * as activeFileMethods from "./methods/activeFileMethods.js";
+export * as basesMethods from "./methods/basesMethods.js";
 export * as commandMethods from "./methods/commandMethods.js";
 export * as openMethods from "./methods/openMethods.js";
 export * as patchMethods from "./methods/patchMethods.js";

--- a/src/services/obsidianRestAPI/methods/basesMethods.ts
+++ b/src/services/obsidianRestAPI/methods/basesMethods.ts
@@ -1,0 +1,160 @@
+/**
+ * @module BasesMethods
+ * @description
+ * Helper methods that wrap HTTP calls to the Bases Bridge REST extension.
+ * These methods are responsible only for constructing the request payload
+ * and delegating execution to the shared request helper provided by the
+ * `ObsidianRestApiService`.
+ */
+
+import { RequestContext } from "../../../utils/index.js";
+import {
+  BaseConfigResponse,
+  BaseConfigUpsertRequest,
+  BaseConfigUpsertResponse,
+  BaseCreateRequest,
+  BaseCreateResponse,
+  BaseQueryRequest,
+  BaseQueryResponse,
+  BaseSchemaResponse,
+  BasesListResponse,
+  BaseUpsertRequest,
+  BaseUpsertResponse,
+  RequestFunction,
+} from "../types.js";
+
+/**
+ * Fetches the list of `.base` files available in the vault.
+ */
+export async function listBases(
+  _request: RequestFunction,
+  context: RequestContext,
+): Promise<BasesListResponse> {
+  return _request<BasesListResponse>(
+    {
+      method: "GET",
+      url: "/bases",
+    },
+    context,
+    "listBases",
+  );
+}
+
+/**
+ * Retrieves the schema/configuration summary of a given base.
+ */
+export async function getBaseSchema(
+  _request: RequestFunction,
+  baseId: string,
+  context: RequestContext,
+): Promise<BaseSchemaResponse> {
+  return _request<BaseSchemaResponse>(
+    {
+      method: "GET",
+      url: `/bases/${encodeURIComponent(baseId)}/schema`,
+    },
+    context,
+    "getBaseSchema",
+  );
+}
+
+/**
+ * Executes a query against a base, optionally leveraging evaluated values.
+ */
+export async function queryBase(
+  _request: RequestFunction,
+  baseId: string,
+  payload: BaseQueryRequest,
+  context: RequestContext,
+): Promise<BaseQueryResponse> {
+  return _request<BaseQueryResponse>(
+    {
+      method: "POST",
+      url: `/bases/${encodeURIComponent(baseId)}/query`,
+      headers: { "Content-Type": "application/json" },
+      data: payload,
+    },
+    context,
+    "queryBase",
+  );
+}
+
+/**
+ * Performs a batch upsert of note properties for rows in a base.
+ */
+export async function upsertBaseRows(
+  _request: RequestFunction,
+  baseId: string,
+  payload: BaseUpsertRequest,
+  context: RequestContext,
+): Promise<BaseUpsertResponse> {
+  return _request<BaseUpsertResponse>(
+    {
+      method: "POST",
+      url: `/bases/${encodeURIComponent(baseId)}/upsert`,
+      headers: { "Content-Type": "application/json" },
+      data: payload,
+    },
+    context,
+    "upsertBaseRows",
+  );
+}
+
+/**
+ * Creates a new `.base` file on disk (or validates the payload).
+ */
+export async function createBase(
+  _request: RequestFunction,
+  payload: BaseCreateRequest,
+  context: RequestContext,
+): Promise<BaseCreateResponse> {
+  return _request<BaseCreateResponse>(
+    {
+      method: "POST",
+      url: "/bases",
+      headers: { "Content-Type": "application/json" },
+      data: payload,
+    },
+    context,
+    "createBase",
+  );
+}
+
+/**
+ * Fetches the YAML configuration of a `.base` file.
+ */
+export async function getBaseConfig(
+  _request: RequestFunction,
+  baseId: string,
+  context: RequestContext,
+): Promise<BaseConfigResponse> {
+  return _request<BaseConfigResponse>(
+    {
+      method: "GET",
+      url: `/bases/${encodeURIComponent(baseId)}/config`,
+    },
+    context,
+    "getBaseConfig",
+  );
+}
+
+/**
+ * Replaces or validates the YAML/JSON configuration of a `.base` file.
+ */
+export async function upsertBaseConfig(
+  _request: RequestFunction,
+  baseId: string,
+  payload: BaseConfigUpsertRequest,
+  context: RequestContext,
+): Promise<BaseConfigUpsertResponse> {
+  return _request<BaseConfigUpsertResponse>(
+    {
+      method: "PUT",
+      url: `/bases/${encodeURIComponent(baseId)}/config`,
+      headers: { "Content-Type": "application/json" },
+      data: payload,
+    },
+    context,
+    "upsertBaseConfig",
+  );
+}

--- a/src/services/obsidianRestAPI/service.ts
+++ b/src/services/obsidianRestAPI/service.ts
@@ -16,6 +16,7 @@ import {
   requestContextService,
 } from "../../utils/index.js"; // Added requestContextService
 import * as activeFileMethods from "./methods/activeFileMethods.js";
+import * as basesMethods from "./methods/basesMethods.js";
 import * as commandMethods from "./methods/commandMethods.js";
 import * as openMethods from "./methods/openMethods.js";
 import * as patchMethods from "./methods/patchMethods.js";
@@ -24,6 +25,17 @@ import * as searchMethods from "./methods/searchMethods.js";
 import * as vaultMethods from "./methods/vaultMethods.js";
 import {
   ApiStatusResponse, // Import PatchOptions type
+  BaseConfigResponse,
+  BaseConfigUpsertRequest,
+  BaseConfigUpsertResponse,
+  BaseCreateRequest,
+  BaseCreateResponse,
+  BaseQueryRequest,
+  BaseQueryResponse,
+  BaseSchemaResponse,
+  BasesListResponse,
+  BaseUpsertRequest,
+  BaseUpsertResponse,
   ComplexSearchResult,
   NoteJson,
   NoteStat,
@@ -351,6 +363,105 @@ export class ObsidianRestApiService {
       this._request.bind(this),
       query,
       contentType,
+      context,
+    );
+  }
+
+  // --- Bases Bridge Methods ---
+
+  /**
+   * Lists all `.base` files discovered by the Bases Bridge.
+   */
+  async listBases(context: RequestContext): Promise<BasesListResponse> {
+    return basesMethods.listBases(this._request.bind(this), context);
+  }
+
+  /**
+   * Retrieves schema information for a specific base.
+   */
+  async getBaseSchema(
+    baseId: string,
+    context: RequestContext,
+  ): Promise<BaseSchemaResponse> {
+    return basesMethods.getBaseSchema(
+      this._request.bind(this),
+      baseId,
+      context,
+    );
+  }
+
+  /**
+   * Executes a query against the Bases Bridge.
+   */
+  async queryBase(
+    baseId: string,
+    payload: BaseQueryRequest,
+    context: RequestContext,
+  ): Promise<BaseQueryResponse> {
+    return basesMethods.queryBase(
+      this._request.bind(this),
+      baseId,
+      payload,
+      context,
+    );
+  }
+
+  /**
+   * Performs a batch upsert against the Bases Bridge.
+   */
+  async upsertBaseRows(
+    baseId: string,
+    payload: BaseUpsertRequest,
+    context: RequestContext,
+  ): Promise<BaseUpsertResponse> {
+    return basesMethods.upsertBaseRows(
+      this._request.bind(this),
+      baseId,
+      payload,
+      context,
+    );
+  }
+
+  /**
+   * Creates a new `.base` file or validates the payload without writing.
+   */
+  async createBase(
+    payload: BaseCreateRequest,
+    context: RequestContext,
+  ): Promise<BaseCreateResponse> {
+    return basesMethods.createBase(
+      this._request.bind(this),
+      payload,
+      context,
+    );
+  }
+
+  /**
+   * Retrieves the YAML/JSON configuration for a `.base` file.
+   */
+  async getBaseConfig(
+    baseId: string,
+    context: RequestContext,
+  ): Promise<BaseConfigResponse> {
+    return basesMethods.getBaseConfig(
+      this._request.bind(this),
+      baseId,
+      context,
+    );
+  }
+
+  /**
+   * Updates or validates the configuration for a `.base` file.
+   */
+  async upsertBaseConfig(
+    baseId: string,
+    payload: BaseConfigUpsertRequest,
+    context: RequestContext,
+  ): Promise<BaseConfigUpsertResponse> {
+    return basesMethods.upsertBaseConfig(
+      this._request.bind(this),
+      baseId,
+      payload,
       context,
     );
   }

--- a/src/services/obsidianRestAPI/types.ts
+++ b/src/services/obsidianRestAPI/types.ts
@@ -123,6 +123,184 @@ export interface ApiError {
 }
 
 /**
+ * Summary information for a Base definition discovered in the vault.
+ */
+export interface BaseSummary {
+  id: string;
+  name: string;
+  path: string;
+}
+
+/**
+ * Response returned by the bridge when listing bases.
+ */
+export interface BasesListResponse {
+  bases: BaseSummary[];
+}
+
+/**
+ * Property description inside a base schema.
+ */
+export interface BaseSchemaProperty {
+  key: string;
+  kind: "note" | "file" | "formula" | "unknown";
+  displayName?: string;
+  valueType?: string;
+}
+
+/**
+ * View description exposed by a base schema.
+ */
+export interface BaseSchemaView {
+  name: string;
+  type: string;
+  limit?: number;
+  order?: string[];
+  filters?: Record<string, unknown> | string[] | undefined;
+  description?: string;
+}
+
+/**
+ * Detailed schema information for a given base.
+ */
+export interface BaseSchemaResponse {
+  id: string;
+  path: string;
+  name?: string;
+  properties: BaseSchemaProperty[];
+  formulas?: Record<string, unknown>;
+  views: BaseSchemaView[];
+  filters?: Record<string, unknown>;
+}
+
+/**
+ * Request payload accepted by the query endpoint.
+ */
+export interface BaseQueryRequest {
+  view?: string;
+  filter?: Record<string, unknown>;
+  sort?: Array<{
+    prop: string;
+    dir?: "asc" | "desc";
+  }>;
+  limit?: number;
+  page?: number;
+  evaluate?: boolean;
+}
+
+/**
+ * Structure of a row returned by the query endpoint.
+ */
+export interface BaseQueryRow {
+  file: {
+    path: string;
+    name: string;
+  };
+  props: Record<string, unknown>;
+  computed?: Record<string, unknown>;
+}
+
+/**
+ * Response payload emitted by the query endpoint.
+ */
+export interface BaseQueryResponse {
+  total: number;
+  page: number;
+  rows: BaseQueryRow[];
+  evaluate?: boolean;
+  source?: "engine" | "fallback";
+}
+
+/**
+ * Operation accepted by the upsert endpoint.
+ */
+export interface BaseUpsertOperation {
+  file: string;
+  set?: Record<string, unknown>;
+  unset?: string[];
+  expected_mtime?: number;
+}
+
+/**
+ * Request payload accepted by the upsert endpoint.
+ */
+export interface BaseUpsertRequest {
+  operations: BaseUpsertOperation[];
+  continueOnError?: boolean;
+}
+
+/**
+ * Result for a single upsert operation.
+ */
+export interface BaseUpsertResult {
+  file: string;
+  mtime: number;
+  changed?: {
+    keys: string[];
+    unset?: string[];
+  };
+  warnings?: string[];
+  error?: {
+    code: string;
+    message: string;
+  };
+}
+
+/**
+ * Response payload emitted by the upsert endpoint.
+ */
+export interface BaseUpsertResponse {
+  ok: boolean;
+  results: BaseUpsertResult[];
+}
+
+/**
+ * Request payload used to create a new base file.
+ */
+export interface BaseCreateRequest {
+  path: string;
+  spec: Record<string, unknown>;
+  overwrite?: boolean;
+  validateOnly?: boolean;
+}
+
+/**
+ * Response payload when creating a new base.
+ */
+export interface BaseCreateResponse {
+  ok: boolean;
+  id: string;
+  warnings?: string[];
+}
+
+/**
+ * Response when fetching a base configuration as YAML/JSON.
+ */
+export interface BaseConfigResponse {
+  id: string;
+  yaml: string;
+  json?: Record<string, unknown>;
+}
+
+/**
+ * Request payload for updating/replacing a base configuration.
+ */
+export interface BaseConfigUpsertRequest {
+  yaml?: string;
+  json?: Record<string, unknown>;
+  validateOnly?: boolean;
+}
+
+/**
+ * Response payload from updating/replacing a base configuration.
+ */
+export interface BaseConfigUpsertResponse {
+  ok: boolean;
+  id: string;
+  warnings?: string[];
+}
+
+/**
  * Options for PATCH operations.
  */
 export interface PatchOptions {

--- a/src/types-global/shims.d.ts
+++ b/src/types-global/shims.d.ts
@@ -1,0 +1,2 @@
+declare module "@xenova/transformers";
+declare module "json5";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
   "exclude": ["node_modules", "dist", "scripts"]
 }


### PR DESCRIPTION
## Summary
- add an obsidian-bases-bridge plugin that extends the Local REST API with Bases routes, a headless view cache, and a disk fallback
- expose six new bases_* MCP tools plus supporting REST client methods to call the new bridge
- document the Bases bridge workflow and examples in the README and add module shims for optional dependencies
- add a dedicated esbuild build configuration so the plugin copies manifest metadata, supports watch mode, and targets es2018 compatibility

## Testing
- npm run build (plugins/obsidian-bases-bridge)


------
https://chatgpt.com/codex/tasks/task_e_68e5ca76b8cc832aa8cf73d45412e33e